### PR TITLE
Document transient PHP extension dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ So here we go :)
 
 # Installation
 
-Install PHP 7.4, being sure to enable the FFI extension, OpenSSL extension, and mbstring extension (`--with-ffi --with-openssl --enable-mbstring`).
+Install PHP 7.4, being sure to enable the FFI extension, OpenSSL extension, mbstring extension, and zlib extension (`--with-ffi --with-openssl --enable-mbstring --with-zlib`).
 
 Also, you need to install the system dependency `libgccjit`. On Ubuntu:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ So here we go :)
 
 # Installation
 
-Install PHP 7.4, being sure to enable the FFI extension (`--with-ffi`).
+Install PHP 7.4, being sure to enable the FFI extension, OpenSSL extension, and mbstring extension (`--with-ffi --with-openssl --enable-mbstring`).
 
 Also, you need to install the system dependency `libgccjit`. On Ubuntu:
 


### PR DESCRIPTION
Building PHP 7.4 from source with only `--with-ffi` doesn't work, because composer itself demands openssl, and phpunit demands mbstring, so this updates the README to also document the transient extension dependencies and avoid a naive user needing to re-build PHP 7.4 multiple times when following the instructions.