### PR TITLE
Fix typo in variable name

### DIFF
--- a/lib/VM/Variable.php
+++ b/lib/VM/Variable.php
@@ -350,7 +350,7 @@ restart:
                 return $self->float === ((float) $other->integer);
             default:
                 if ($self->type === self::TYPE_INDIRECT) {
-                    $self = $self->indrect;
+                    $self = $self->indirect;
                     goto restart;
                 } elseif ($other->type === self::TYPE_INDIRECT) {
                     $other = $other->indirect;


### PR DESCRIPTION
This fixes one of the obvious bugs caught by phan, where there was
a typo in a property name.