### PR TITLE
Fix functions called with too many variables

### DIFF
--- a/lib/JIT.php
+++ b/lib/JIT.php
@@ -322,7 +322,7 @@ class JIT {
                     if ($op->type === OpCode::TYPE_PRINT) {
                         $this->assignOperand(
                             $block->getOperand($op->arg1),
-                            new Variable($this->context, Variable::TYPE_NATIVE_LONG, Variable::KIND_VALUE, $this->context->constantFromInteger(1), null)
+                            new Variable($this->context, Variable::TYPE_NATIVE_LONG, Variable::KIND_VALUE, $this->context->constantFromInteger(1))
                         );
                     }
                     break;

--- a/lib/JIT/Builtin/Type/Object_.php
+++ b/lib/JIT/Builtin/Type/Object_.php
@@ -342,7 +342,6 @@ class Object_ extends Type {
                     $propset[2],
                     Variable::KIND_VARIABLE,
                     $prop->asRValue(),
-                    $prop
                 );
             }
         }

--- a/lib/JIT/Context.php
+++ b/lib/JIT/Context.php
@@ -380,7 +380,7 @@ class Context {
     ) {
         assert(!$this->scope->variables->contains($op));
         $this->scope->variables[$op] = Variable::fromOp($this, $func, $basicBlock, $block, $op);
-        $this->scope->variables[$op]->initialize($basicBlock);
+        $this->scope->variables[$op]->initialize();
     }
 
     public function setVariableOp(Operand $op, Variable $var) {

--- a/lib/Runtime.php
+++ b/lib/Runtime.php
@@ -165,7 +165,7 @@ class Runtime {
     }
 
     public function run(?Block $block) {
-        return $this->vm->run($block, $this->vmContext);
+        return $this->vm->run($block);
     }
 
 }


### PR DESCRIPTION
This fixes anything where phan identified the call as having
more parameters than the signature dictates. I've blindly removed
parameters from the end of the flagged lines without investigating
further, because that matches the behaviour of how PHP is currently
behaving at these lines.