### PR TITLE
Remove access to private variable from Context

### DIFF
--- a/lib/VM/Context.php
+++ b/lib/VM/Context.php
@@ -33,10 +33,12 @@ class Context {
             case 'null':
                 return new Variable(Variable::TYPE_NULL);
             case 'false':
-                $var = new Variable(Variable::TYPE_BOOLEAN, false);
+                $var = new Variable(Variable::TYPE_BOOLEAN);
+		$var->bool(false);
                 return $var;
             case 'true':
-                $var = new Variable(Variable::TYPE_BOOLEAN, true);
+                $var = new Variable(Variable::TYPE_BOOLEAN);
+		$var->bool(true);
                 return $var;
         }
         if (isset($this->constants[$name])) {

--- a/lib/VM/Variable.php
+++ b/lib/VM/Variable.php
@@ -42,9 +42,8 @@ final class Variable {
     public ?int $typeConstraint = null;
     public ?string $classConstraint = null; 
 
-    public function __construct(int $type = self::TYPE_NULL, bool $boolval=false) {
+    public function __construct(int $type = self::TYPE_NULL) {
         $this->type = $type;
-	$this->bool = $boolval;
     }
 
     public static function mapFromType(Type $type): int {


### PR DESCRIPTION
VM\Context was attempting to set private property VM\Variable->bool
when dealing with a boolean literal. This updates the value to be
injected via the constructor.