### PR TITLE
Remove reference to ->value after toString()

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -17,7 +17,6 @@ return [
 		'PhanUndeclaredClassMethod',
 		'PhanTypeMismatchProperty',
 		'PhanTypeExpectedObjectPropAccessButGotNull',
-		'PhanAccessPropertyPrivate',
 		'PhanUnreferencedUseNormal',
 		'PhanTypeMismatchDimFetchNullable',
 		'PhanTypeMismatchReturn',

--- a/lib/VM.php
+++ b/lib/VM.php
@@ -161,10 +161,10 @@ restart:
                     $value = null;
                     if (!is_null($op->arg3)) {
                         // try NS constant fetch
-                        $value = $this->context->constantFetch($frame->scope[$op->arg3]->toString()->value);
+                        $value = $this->context->constantFetch($frame->scope[$op->arg3]->toString());
                     }
                     if (is_null($value)) {
-                        $value = $this->context->constantFetch($frame->scope[$op->arg2]->toString()->value);
+                        $value = $this->context->constantFetch($frame->scope[$op->arg2]->toString());
                     }
                     if (is_null($value)) {
                         return $this->raise('Unknown constant fetch', $frame);

--- a/lib/VM/Context.php
+++ b/lib/VM/Context.php
@@ -33,12 +33,10 @@ class Context {
             case 'null':
                 return new Variable(Variable::TYPE_NULL);
             case 'false':
-                $var = new Variable(Variable::TYPE_BOOLEAN);
-                $var->bool = false;
+                $var = new Variable(Variable::TYPE_BOOLEAN, false);
                 return $var;
             case 'true':
-                $var = new Variable(Variable::TYPE_BOOLEAN);
-                $var->bool = true;
+                $var = new Variable(Variable::TYPE_BOOLEAN, true);
                 return $var;
         }
         if (isset($this->constants[$name])) {

--- a/lib/VM/Variable.php
+++ b/lib/VM/Variable.php
@@ -42,8 +42,9 @@ final class Variable {
     public ?int $typeConstraint = null;
     public ?string $classConstraint = null; 
 
-    public function __construct(int $type = self::TYPE_NULL) {
+    public function __construct(int $type = self::TYPE_NULL, bool $boolval=false) {
         $this->type = $type;
+	$this->bool = $boolval;
     }
 
     public static function mapFromType(Type $type): int {


### PR DESCRIPTION
This fixes a fatal type error in OpCode::TYPE_CONST_FETCH where it
was attempting to fetch the value property after calling toString().
Since string is not an object, it would always return null.

With this, you can run the "php bin/vm.php foo.php" with the following
foo.php and not crash:

```
<?php
$a = true;
```

(I'm not sure if this causes any regressions with constants since
I can't get the test suite to run with or without this change, but I
can't see how the ->value access after toString would ever work.)
