### PR TITLE
Add support for boolean negation

### DIFF
--- a/lib/VM.php
+++ b/lib/VM.php
@@ -275,6 +275,11 @@ restart:
                         $ht->add($key->toString(), $frame->scope[$op->arg2]);
                     }
                     break;
+                case OpCode::TYPE_BOOLEAN_NOT:
+		    $value = !($frame->scope[$op->arg2]->toBool());
+		    $dst = $frame->scope[$op->arg1];
+		    $dst->bool($value);
+                    break;
                 default:
                     throw new \LogicException("VM OpCode Not Implemented: " . $op->getType());
             }

--- a/test/compliance/cases/bool_test.phpt
+++ b/test/compliance/cases/bool_test.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Basic bool operations
+--FILE--
+<?php
+$a = true;
+
+if ($a) {
+	echo "True\n";
+} else {
+	echo "False\n";
+}
+
+$a = !$a
+echo $a ? "True\n" : "False\n";
+--EXPECT--
+True
+False


### PR DESCRIPTION
This adds support for the TYPE_BOOLEAN_NOT opcode to the VM, allowing
programs as complex as

```
<?php
$a = true;
$b = !$a;
echo $b ? "true" : "false";
```

to run. It also adds a test case in the test/compliance/cases directory,
but I'm not entirely sure how to run those so I'm not entirely sure if it works.