### PR TITLE
Fix phan regressions

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -27,7 +27,6 @@ return [
 		'PhanParamTooFew',
 		'PhanUndeclaredConstant',
 		'PhanTypeExpectedObjectPropAccess',
-		'PhanParamTooMany',
 		'PhanUndeclaredTypeParameter',
 		'PhanUndeclaredProperty',
 		'PhanTypeNonVarPassByRef',

--- a/lib/JIT/Builtin/Type/Value.php
+++ b/lib/JIT/Builtin/Type/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 # This file is generated, changes you make will be lost.
-# Make your changes in /home/ircmaxell/Workspace/PHP-Compiler/PHP-Compiler/lib/JIT/Builtin/Type/Value.pre instead.
+# Make your changes in /home/driusan/Code/php-compiler/lib/JIT/Builtin/Type/Value.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
@@ -61,7 +61,7 @@ class Value extends Type
     {
     }
 
-    public function castToLong(PHPLLVM\Value $value): Value
+    public function castToLong(PHPLLVM\Value $value): void
     {
         $offset =
             $this->context->structFieldMap[
@@ -133,7 +133,7 @@ class Value extends Type
         array_pop($__switches);
     }
 
-    public function writeLong(PHPLLVM\Value $value, int $value): void
+    public function writeLong(PHPLLVM\Value $value, int $val): void
     {
         $type = $this->context
             ->getTypeFromString('int8')
@@ -165,12 +165,12 @@ class Value extends Type
             ->getTypeFromString('int32')
             ->constInt(0, false);
         $type = $this->context->getTypeFromString('int64');
-        if (!is_object($value)) {
-            $result = $type->constInt($value, false);
-        } elseif ($value->typeOf()->getWidth() >= $type->getWidth()) {
-            $result = $this->context->builder->truncOrBitCast($value, $type);
+        if (!is_object($val)) {
+            $result = $type->constInt($val, false);
+        } elseif ($val->typeOf()->getWidth() >= $type->getWidth()) {
+            $result = $this->context->builder->truncOrBitCast($val, $type);
         } else {
-            $result = $this->context->builder->zExtOrBitCast($value, $type);
+            $result = $this->context->builder->zExtOrBitCast($val, $type);
         }
         $this->context->builder->store(
             $result,

--- a/lib/JIT/Builtin/Type/Value.pre
+++ b/lib/JIT/Builtin/Type/Value.pre
@@ -34,7 +34,7 @@ class Value extends Type {
     public function initialize(): void {
     }
 
-    public function castToLong(PHPLLVM\Value $value): Value {
+    public function castToLong(PHPLLVM\Value $value): void {
         compile {
             $type = $value->type;
             switch $type {
@@ -53,14 +53,14 @@ class Value extends Type {
         }
     }
 
-    public function writeLong(PHPLLVM\Value $value, int $value): void {
+    public function writeLong(PHPLLVM\Value $value, int $val): void {
         compile {
             $type = (int8) Variable::TYPE_NATIVE_LONG;
             $value->type = $type;
             $ptr = &$value->value;
             $resultPtr = (int64*) $ptr;
             $offset = (int32) 0;
-            $result = (int64) $value;
+            $result = (int64) $val;
             $ptr[$offset] = $result;
         }
     }

--- a/lib/JIT/Context.php
+++ b/lib/JIT/Context.php
@@ -432,7 +432,7 @@ class Context {
         Block $block
     ): void {
         foreach ($block->orig->deadOperands as $op) {
-            $this->scope->variables[$op]->free($basicBlock);
+            $this->scope->variables[$op]->free();
         }
     }
 


### PR DESCRIPTION
- There was 1 "PhanParamTooMany" errors missed, so it's fixed and the
  error class is no longer ignored
- The "return" statements in JIT/Builtin/Type/Value->castToLong are in
  a compile {} block for the JIT, so they generate IR, but don't return
  from the PHP function itself. Update the function PHP signature to match
  the return value of the generated code.
- Both parameters in Value->writeLong were named "$value". (I had
  to guess at which one was intended to be the int and which the
  PHPLLVM\Value in the code, so I'm not sure if my change here
  is correct.)

The remaining changes to lib/JIT/Builtin/Type/Value.php are just
from regenerating the code from Value.pre.