### PR TITLE
Fix type incompatiblity errors in memory manager

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -38,8 +38,6 @@ return [
 		'PhanNonClassMethodCall',
 		'PhanUndeclaredTypeReturnType',
 		'PhanUndeclaredVariableDim',
-		'PhanParamSignatureRealMismatchTooManyRequiredParameters',
-		'PhanParamSignatureMismatch',
 		'PhanTypeInvalidDimOffset',
 	],
 ];

--- a/lib/JIT/Builtin/MemoryManager.php
+++ b/lib/JIT/Builtin/MemoryManager.php
@@ -1,15 +1,7 @@
 <?php
 
-declare(strict_types=1);
-
-/**
- * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
- *
- * @copyright 2015 Anthony Ferrara. All rights reserved
- * @license MIT See LICENSE at the root of the project for more info
- */
-
-// Make your changes in /home/ircmaxell/Workspace/PHP-Compiler/PHP-Compiler/script/../lib/JIT/Builtin/MemoryManager.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /home/driusan/Code/php-compiler/script/../lib/JIT/Builtin/MemoryManager.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
@@ -17,14 +9,24 @@ declare(strict_types=1);
  * @copyright 2015 Anthony Ferrara. All rights reserved
  * @license MIT See LICENSE at the root of the project for more info
  */
+
 namespace PHPCompiler\JIT\Builtin;
 
 use PHPCompiler\JIT\Builtin;
+use PHPCompiler\JIT\Context;
 
 use PHPLLVM;
 
 abstract class MemoryManager extends Builtin
 {
+    public static function load(Context $context, int $loadtype): self
+    {
+        if ($loadtype === Builtin::LOAD_TYPE_STANDALONE) {
+            return new MemoryManager\Native($context, $loadtype);
+        }
+        return new MemoryManager\PHP($context, $loadtype);
+    }
+
     public function register(): void
     {
         $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(

--- a/lib/JIT/Builtin/MemoryManager.pre
+++ b/lib/JIT/Builtin/MemoryManager.pre
@@ -10,10 +10,18 @@
 namespace PHPCompiler\JIT\Builtin;
 
 use PHPCompiler\JIT\Builtin;
+use PHPCompiler\JIT\Context;
+
 
 use PHPLLVM;
 
 abstract class MemoryManager extends Builtin {
+    static public function load(Context $context, int $loadtype) : self {
+        if ($loadtype === Builtin::LOAD_TYPE_STANDALONE) {
+            return new MemoryManager\Native($context, $loadtype);
+        }
+        return new MemoryManager\PHP($context, $loadtype);
+    }
 
     public function register(): void {
         declare {

--- a/lib/JIT/Builtin/MemoryManager/Native.php
+++ b/lib/JIT/Builtin/MemoryManager/Native.php
@@ -1,15 +1,7 @@
 <?php
 
-declare(strict_types=1);
-
-/**
- * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
- *
- * @copyright 2015 Anthony Ferrara. All rights reserved
- * @license MIT See LICENSE at the root of the project for more info
- */
-
-// Make your changes in /home/ircmaxell/Workspace/PHP-Compiler/PHP-Compiler/script/../lib/JIT/Builtin/MemoryManager/Native.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /home/driusan/Code/php-compiler/script/../lib/JIT/Builtin/MemoryManager/Native.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
@@ -17,6 +9,7 @@ declare(strict_types=1);
  * @copyright 2015 Anthony Ferrara. All rights reserved
  * @license MIT See LICENSE at the root of the project for more info
  */
+
 namespace PHPCompiler\JIT\Builtin\MemoryManager;
 
 use PHPCompiler\JIT\Builtin\MemoryManager;

--- a/lib/JIT/Builtin/MemoryManager/PHP.php
+++ b/lib/JIT/Builtin/MemoryManager/PHP.php
@@ -1,8 +1,9 @@
 <?php
 
-declare(strict_types=1);
+# This file is generated, changes you make will be lost.
+# Make your changes in /home/driusan/Code/php-compiler/script/../lib/JIT/Builtin/MemoryManager/PHP.pre instead.
 
-/**
+/*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
  *
  * @copyright 2015 Anthony Ferrara. All rights reserved
@@ -18,113 +19,110 @@ class PHP extends MemoryManager
     public function register(): void
     {
         parent::register();
-        $this->context->helper->importFunction(
-            '_efree',
-            'void',
+        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+            $this->context->getTypeFromString('int8*'),
             false,
-            'void*',
-            ...$this->expandDebugDecl()
+            $this->context->getTypeFromString('size_t')
         );
-        $this->context->helper->importfunction(
-            '_emalloc',
-            'void*',
-            false,
-            'size_t',
-            ...$this->expandDebugDecl()
+        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
+            'emalloc',
+            $fntype___cfcd208495d565ef66e7dff9f98764da
         );
-        $this->context->helper->importFunction(
-            '_erealloc',
-            'void*',
+
+        $this->context->registerFunction(
+            'emalloc',
+            $fn___cfcd208495d565ef66e7dff9f98764da
+        );
+
+        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+            $this->context->getTypeFromString('int8*'),
             false,
-            'void*',
-            'size_t',
-            ...$this->expandDebugDecl()
+            $this->context->getTypeFromString('int8*'),
+            $this->context->getTypeFromString('size_t')
+        );
+        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
+            'erealloc',
+            $fntype___cfcd208495d565ef66e7dff9f98764da
+        );
+
+        $this->context->registerFunction(
+            'erealloc',
+            $fn___cfcd208495d565ef66e7dff9f98764da
+        );
+
+        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+            $this->context->getTypeFromString('void'),
+            false,
+            $this->context->getTypeFromString('int8*')
+        );
+        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
+            'efree',
+            $fntype___cfcd208495d565ef66e7dff9f98764da
+        );
+
+        $this->context->registerFunction(
+            'efree',
+            $fn___cfcd208495d565ef66e7dff9f98764da
         );
     }
 
-    public function malloc(\gcc_jit_rvalue_ptr $size, \gcc_jit_type_ptr $type): \gcc_jit_rvalue_ptr
+    public function implement(): void
     {
-        $void = $this->context->helper->call(
-            '_emalloc',
-            $size,
-            ...$this->expandDebugArgs()
+        $fn___c4ca4238a0b923820dcc509a6f75849b = $this->context->lookupFunction(
+            '__mm__malloc'
         );
+        $block___c4ca4238a0b923820dcc509a6f75849b = $fn___c4ca4238a0b923820dcc509a6f75849b->appendBasicBlock(
+            'main'
+        );
+        $this->context->builder->positionAtEnd(
+            $block___c4ca4238a0b923820dcc509a6f75849b
+        );
+        $size = $fn___c4ca4238a0b923820dcc509a6f75849b->getParam(0);
 
-        return \gcc_jit_context_new_cast(
-            $this->context->context,
-            null,
+        $result = $this->context->builder->call(
+            $this->context->lookupFunction('emalloc'),
+            $size
+        );
+        $this->context->builder->returnValue($result);
+
+        $this->context->builder->clearInsertionPosition();
+        $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3 = $this->context->lookupFunction(
+            '__mm__realloc'
+        );
+        $block___eccbc87e4b5ce2fe28308fd9f2a7baf3 = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->appendBasicBlock(
+            'main'
+        );
+        $this->context->builder->positionAtEnd(
+            $block___eccbc87e4b5ce2fe28308fd9f2a7baf3
+        );
+        $void = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->getParam(0);
+        $size = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->getParam(1);
+
+        $result = $this->context->builder->call(
+            $this->context->lookupFunction('erealloc'),
             $void,
-            $type
+            $size
         );
-    }
+        $this->context->builder->returnValue($result);
 
-    public function realloc(\gcc_jit_rvalue_ptr $ptr, \gcc_jit_rvalue_ptr $size, \gcc_jit_type_ptr $type): \gcc_jit_rvalue_ptr
-    {
-        $void = $this->context->helper->call(
-            '_erealloc',
-            \gcc_jit_context_new_cast(
-                $this->context->context,
-                $this->context->location(),
-                $ptr,
-                $this->context->getTypeFromString('void*')
-            ),
-            $size,
-            ...$this->expandDebugArgs()
+        $this->context->builder->clearInsertionPosition();
+        $fn___e4da3b7fbbce2345d7772b0674a318d5 = $this->context->lookupFunction(
+            '__mm__free'
         );
-
-        return \gcc_jit_context_new_cast(
-            $this->context->context,
-            null,
-            $void,
-            $type
+        $block___e4da3b7fbbce2345d7772b0674a318d5 = $fn___e4da3b7fbbce2345d7772b0674a318d5->appendBasicBlock(
+            'main'
         );
-    }
-
-    public function free(
-        \gcc_jit_block_ptr $block,
-        \gcc_jit_rvalue_ptr $ptr
-    ): void {
-        $this->context->helper->eval(
-            $block,
-            $this->context->helper->call(
-                '_efree',
-                $this->context->helper->cast($ptr, 'void*'),
-                ...$this->expandDebugArgs()
-            )
+        $this->context->builder->positionAtEnd(
+            $block___e4da3b7fbbce2345d7772b0674a318d5
         );
-    }
+        $void = $fn___e4da3b7fbbce2345d7772b0674a318d5->getParam(0);
 
-    private function expandDebugDecl(): array
-    {
-        if (\PHP_DEBUG) {
-            return [
-                'const char*',
-                'uint32_t',
-                'const char*',
-                'uint32_t',
-            ];
-        }
+        $this->context->builder->call(
+            $this->context->lookupFunction('efree'),
+            $void
+        );
+        $this->context->builder->returnVoid();
 
-        return [];
-    }
-
-    private function expandDebugArgs(): array
-    {
-        if (\PHP_DEBUG) {
-            return [
-                $this->context->constantFromString('jit'),
-                $this->context->helper->cast(
-                    $this->context->constantFromInteger(2),
-                    'uint32_t'
-                ),
-                $this->context->constantFromString('jit'),
-                $this->context->helper->cast(
-                    $this->context->constantFromInteger(2),
-                    'uint32_t'
-                ),
-            ];
-        }
-
-        return [];
+        $this->context->builder->clearInsertionPosition();
     }
 }

--- a/lib/JIT/Builtin/MemoryManager/PHP.pre
+++ b/lib/JIT/Builtin/MemoryManager/PHP.pre
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
+ *
+ * @copyright 2015 Anthony Ferrara. All rights reserved
+ * @license MIT See LICENSE at the root of the project for more info
+ */
+
+namespace PHPCompiler\JIT\Builtin\MemoryManager;
+
+use PHPCompiler\JIT\Builtin\MemoryManager;
+
+class PHP extends MemoryManager {
+    public function register(): void {
+        parent::register();
+        declare {
+            function emalloc(size_t): int8*;
+            function erealloc(int8*, size_t): int8*;
+            function efree(int8*): void;            
+        }
+    } 
+
+    public function implement(): void {
+        compile {
+            function __mm__malloc($size) {
+                $result = emalloc($size);
+                return $result;
+            }
+        }
+        compile {
+            function __mm__realloc($void, $size) {
+                $result = erealloc($void, $size);
+                return $result;
+            }
+        }
+        compile {
+            function __mm__free($void) {
+                efree($void);
+                return;
+            }
+        }
+    }
+
+}

--- a/lib/JIT/Context.php
+++ b/lib/JIT/Context.php
@@ -91,7 +91,7 @@ class Context {
         $this->helper = new Helper($this);
         
         $this->refcount = new Builtin\Refcount($this, $loadType);
-        $this->memory = new Builtin\MemoryManager\Native($this, $loadType);
+        $this->memory = Builtin\MemoryManager::load($this, $loadType);
         $this->output = new Builtin\Output($this, $loadType);
         $this->type = new Builtin\Type($this, $loadType);
         $this->internal = new Builtin\Internal($this, $loadType);


### PR DESCRIPTION
This updates the PHP memory manager based on the Native
memory manager preprocessor, and simply changes the names
of the malloc family function calls.

A MemoryManager::load function is re-added to select the
memory manager to use based on the loadtype passed.

Note: MemoryManager.pre won't currently compile for me
on the master branch because of an unknown problem with
the $extra parameter in the compile block. The MemoryManager.php
generated in this PR wasn't directly compiled, but compiled
with those lines commented out and then partially staged
with "git add -p". This code is not well tested, but fixes #22.