### PR TITLE
Add Circle CI config and setup php-ast in docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,4 +7,5 @@ jobs:
                         - checkout
                         - run: make docker-build
                         - run: make build
+                        - run: make phan
                         - run: make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+
+jobs:
+        build:
+                machine: true
+                steps:
+                        - checkout
+                        - run: make docker-build
+                        - run: make build
+                        - run: make test

--- a/Docker/ubuntu-16.04/Dockerfile
+++ b/Docker/ubuntu-16.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 RUN mkdir compiler && \
     apt-get update && \
-    apt-get -y install git build-essential llvm-4.0-dev clang-4.0 unzip curl libcurl4-openssl-dev autoconf libssl-dev libgd-dev libzip-dev bison re2c libxml2-dev libsqlite3-dev libonig-dev vim
+    apt-get -y install git build-essential llvm-4.0-dev clang-4.0 unzip curl libcurl4-openssl-dev autoconf libssl-dev libgd-dev libzip-dev bison re2c libxml2-dev libsqlite3-dev libonig-dev vim clang
 
 RUN curl -L https://github.com/php/php-src/archive/PHP-7.4.zip -o PHP-7.4.zip && unzip PHP-7.4.zip && mv php-src-PHP-7.4 php
 
@@ -17,10 +17,17 @@ WORKDIR ../
 
 RUN curl --silent --show-error https://getcomposer.org/installer | php
 
-ENV PHP="/usr/local/bin/php" PHP_7_4="/usr/local/bin/php" PHP_CS_FIXER_IGNORE_ENV="true"
+ENV PHP="/usr/local/bin/php", PHP_7_4="/usr/local/bin/php", PHP_CS_FIXER_IGNORE_ENV="true"
 
 COPY php.ini /usr/local/lib/php.ini
 
-WORKDIR compiler
+WORKDIR php-ast
+RUN git clone https://github.com/nikic/php-ast .
+RUN phpize
+RUN ./configure
+RUN make
+RUN make install
+
+WORKDIR ../compiler
 
 CMD ["/bin/bash"]

--- a/Docker/ubuntu-16.04/php.ini
+++ b/Docker/ubuntu-16.04/php.ini
@@ -1,1 +1,2 @@
 memory_limit=-1
+extension=ast.so

--- a/Docker/ubuntu-18.04/Dockerfile
+++ b/Docker/ubuntu-18.04/Dockerfile
@@ -21,6 +21,13 @@ ENV PHP="/usr/local/bin/php", PHP_7_4="/usr/local/bin/php", PHP_CS_FIXER_IGNORE_
 
 COPY php.ini /usr/local/lib/php.ini
 
-WORKDIR compiler
+WORKDIR php-ast
+RUN git clone https://github.com/nikic/php-ast .
+RUN phpize
+RUN ./configure
+RUN make
+RUN make install
+
+WORKDIR ../compiler
 
 CMD ["/bin/bash"]

--- a/Docker/ubuntu-18.04/php.ini
+++ b/Docker/ubuntu-18.04/php.ini
@@ -1,1 +1,2 @@
 memory_limit=-1
+extension=ast.so

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ benchmark: rebuild-changed
 .PHONY: build
 build: docker-build composer-install rebuild fix test rebuild-examples
 
+.PHONY: phan
+phan:
+	docker run -v $(shell pwd):/compiler php-compiler-16-04 php vendor/bin/phan
+
 .PHONY: test
 test: rebuild-changed
 	docker run -v $(shell pwd):/compiler php-compiler-16-04 php vendor/bin/phpunit


### PR DESCRIPTION
This sets up the php-ast extension in the Docker images so that they can be used to run phan.

It also sets up a Circle CI config that builds the container and runs both phan and phpunit.

