### PR TITLE
Fix associative arrays when run under bin/vm.php

### DIFF
--- a/lib/VM/Variable.php
+++ b/lib/VM/Variable.php
@@ -107,6 +107,9 @@ final class Variable {
         $this->integer = $value;
     }
 
+    public function isInt(): bool {
+        return $this->type === self::TYPE_INTEGER;
+    }
     public function toInt(): int {
         switch ($this->type) {
             case self::TYPE_NULL:

--- a/test/compliance/cases/arrayindex_test.phpt.disabled
+++ b/test/compliance/cases/arrayindex_test.phpt.disabled
@@ -1,0 +1,14 @@
+--TEST--
+Basic array indexing
+--FILE--
+<?php
+$scalar = [1, 2, 3];
+
+echo "$scalar[2]\n";
+
+$hashed = ["foo" => 1, "bar" => 2, "baz" => 3];
+
+echo "$hashed[bar]\n";
+--EXPECT--
+3
+2


### PR DESCRIPTION
This fixes associative arrays when using bin/vm.php,
where the opcode was making a reference to an undefined
isInt() function.

It also adds a basic test for accessing both associative
and numeric arrays, but the test is disabled because the
TYPE_ARRAY_INIT opcode isn't supported by the JIT.