### PR TITLE
Fix PhanTypeMismatchArgumentInternal class error

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -28,7 +28,6 @@ return [
 		'PhanUndeclaredProperty',
 		'PhanTypeNonVarPassByRef',
 		'PhanUnusedGotoLabel',
-		'PhanTypeMismatchArgumentInternal',
 		'PhanTypeMismatchDimFetch',
 		'PhanTypeMismatchDimAssignment',
 		'PhanTypeMismatchDimFetch',

--- a/lib/JIT/Result.php
+++ b/lib/JIT/Result.php
@@ -60,6 +60,8 @@ class Result {
         $cb = FFI::new($callbackType);
         FFI::memcpy(
             FFI::addr($cb),
+	    // Incorrectly flagged due to https://github.com/phan/phan/issues/2659
+	    // @phan-suppress-next-line PhanTypeMismatchArgumentInternal
             FFI::addr($code),
             FFI::sizeof($cb)
         );


### PR DESCRIPTION
There aren't actually any errors of this type, only a bug with phan not interpretting FFI assignments properly.