### PR TITLE
Fix PhanUnreferencedUseNormal from phan

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -12,11 +12,9 @@ return [
 	'suppress_issue_types' => [
 		'PhanTypeInvalidBitwiseBinaryOperator',
 		'PhanTypeObjectUnsetDeclaredProperty',
-		'PhanUnreferencedUseNormal',
 		'PhanUndeclaredClassMethod',
 		'PhanTypeMismatchProperty',
 		'PhanTypeExpectedObjectPropAccessButGotNull',
-		'PhanUnreferencedUseNormal',
 		'PhanTypeMismatchDimFetchNullable',
 		'PhanUndeclaredMethod',
 		'PhanTypeMismatchArgument',

--- a/lib/Block.php
+++ b/lib/Block.php
@@ -9,9 +9,10 @@
 
 namespace PHPCompiler;
 
+// used as a property type.
+// @phan-suppress-next-line PhanUnreferencedUseNormal
 use PHPCfg\Func;
 use PHPCfg\Block as CfgBlock;
-use PHPCfg\Op\Expr;
 use PHPCfg\Operand;
 use PHPCompiler\VM\Context;
 use PHPCompiler\VM\Variable;

--- a/lib/Compiler.php
+++ b/lib/Compiler.php
@@ -9,6 +9,8 @@
 
 namespace PHPCompiler;
 
+// This is used as a property type, phan is confused.
+// @phan-suppress-next-line PhanUnreferencedUseNormal
 use SplObjectStorage;
 use PHPCfg\Func as CfgFunc;
 use PHPCfg\Op;
@@ -17,7 +19,6 @@ use PHPCfg\Operand;
 use PHPCfg\Script;
 use PHPTypes\Type;
 use PHPCompiler\VM\Variable;
-use PHPCompiler\NativeType\NativeArray;
 
 class Compiler {
 

--- a/lib/Func.php
+++ b/lib/Func.php
@@ -10,7 +10,6 @@
 namespace PHPCompiler;
 
 use PHPCompiler\VM\Context;
-use PHPCompiler\VM\Variable;
 
 abstract class Func {
 

--- a/lib/Func/PHP.php
+++ b/lib/Func/PHP.php
@@ -13,7 +13,6 @@ use PHPCompiler\Func;
 use PHPCompiler\Frame;
 use PHPCompiler\Block;
 use PHPCompiler\VM\Context;
-use PHPCompiler\VM\Variable;
 
 final class PHP extends Func {
 

--- a/lib/JIT.php
+++ b/lib/JIT.php
@@ -14,15 +14,11 @@ namespace PHPCompiler;
 
 use PHPCfg\Operand;
 use PHPCfg\Op;
-use PHPCfg\Block as CfgBlock;
 use PHPTypes\Type;
-use PHPCompiler\JIT\Analyzer;
 use PHPCompiler\JIT\Context;
 use PHPCompiler\JIT\Variable;
 
 use PHPCompiler\Func as CoreFunc;
-use PHPCompiler\JIT\Func as JITFunc;
-use PHPCompiler\NativeType\NativeArray as NativeArray;
 
 use PHPLLVM;
 

--- a/lib/JIT.pre
+++ b/lib/JIT.pre
@@ -11,15 +11,11 @@ namespace PHPCompiler;
 
 use PHPCfg\Operand;
 use PHPCfg\Op;
-use PHPCfg\Block as CfgBlock;
 use PHPTypes\Type;
-use PHPCompiler\JIT\Analyzer;
 use PHPCompiler\JIT\Context;
 use PHPCompiler\JIT\Variable;
 
 use PHPCompiler\Func as CoreFunc;
-use PHPCompiler\JIT\Func as JITFunc;
-use PHPCompiler\NativeType\NativeArray as NativeArray;
 
 use PHPLLVM;
 

--- a/lib/JIT/Builtin/Type.php
+++ b/lib/JIT/Builtin/Type.php
@@ -11,8 +11,6 @@ namespace PHPCompiler\JIT\Builtin;
 
 use PHPCompiler\JIT\Builtin;
 
-use PHPLLVM;
-
 class Type extends Builtin {
 
     public Type\String_ $string;

--- a/lib/JIT/Builtin/Type/HashTable.php
+++ b/lib/JIT/Builtin/Type/HashTable.php
@@ -10,8 +10,6 @@
 namespace PHPCompiler\JIT\Builtin\Type;
 
 use PHPCompiler\JIT\Builtin\Type;
-use PHPCompiler\JIT\Builtin\Refcount;
-use PHPCompiler\JIT\Variable;
 
 class HashTable extends Type {
     private \gcc_jit_struct_ptr $struct;

--- a/lib/JIT/Builtin/Type/MaskedArray.php
+++ b/lib/JIT/Builtin/Type/MaskedArray.php
@@ -9,12 +9,8 @@
 
 namespace PHPCompiler\JIT\Builtin\Type;
 
-use PHPCfg\Operand;
-use PHPCfg\Operand\Literal;
 use PHPCompiler\JIT\Builtin\Type;
 use PHPCompiler\JIT\Builtin\Refcount;
-use PHPCompiler\JIT\Variable;
-use PHPCompiler\JIT\Func;
 
 class MaskedArray extends Type {
     private \gcc_jit_struct_ptr $struct;

--- a/lib/JIT/Builtin/Type/Value.php
+++ b/lib/JIT/Builtin/Type/Value.php
@@ -13,10 +13,7 @@
 namespace PHPCompiler\JIT\Builtin\Type;
 
 use PHPCompiler\JIT\Builtin\Type;
-use PHPCompiler\JIT\Builtin\Refcount;
 use PHPCompiler\JIT\Variable;
-
-use PHPLLVM;
 
 class Value extends Type {
 

--- a/lib/JIT/Builtin/Type/Value.pre
+++ b/lib/JIT/Builtin/Type/Value.pre
@@ -10,10 +10,7 @@
 namespace PHPCompiler\JIT\Builtin\Type;
 
 use PHPCompiler\JIT\Builtin\Type;
-use PHPCompiler\JIT\Builtin\Refcount;
 use PHPCompiler\JIT\Variable;
-
-use PHPLLVM;
 
 class Value extends Type {
 

--- a/lib/JIT/Context.php
+++ b/lib/JIT/Context.php
@@ -11,10 +11,8 @@ namespace PHPCompiler\JIT;
 
 use PHPCfg\Operand;
 use PHPCompiler\Runtime;
-use PHPCompiler\Handler;
 use PHPCompiler\Block;
 use PHPCompiler\VM\Variable as VMVariable;
-use PHPCompiler\Handler\Builtins;
 use PHPTypes\Type;
 
 use PHPLLVM;

--- a/lib/JIT/Scope.php
+++ b/lib/JIT/Scope.php
@@ -9,10 +9,6 @@
 
 namespace PHPCompiler\JIT;
 
-use PHPCfg\Operand;
-
-use PHPLLVM;
-
 class Scope {
     public int $classId = 0;
     public \SplObjectStorage $blockStorage;

--- a/lib/Runtime.php
+++ b/lib/Runtime.php
@@ -14,7 +14,6 @@ use PHPCfg\Parser;
 use PHPCfg\Traverser;
 use PHPCfg\LivenessDetector;
 use PHPCfg\Visitor;
-use PHPCfg\Printer as CfgPrinter;
 use PHPCfg\Script;
 use PHPTypes\TypeReconstructor;
 use PhpParser\NodeTraverser;

--- a/lib/VM.php
+++ b/lib/VM.php
@@ -9,7 +9,6 @@
 
 namespace PHPCompiler;
 
-use PHPTypes\Type;
 use PHPCompiler\VM\Context;
 use PHPCompiler\VM\ClassEntry;
 use PHPCompiler\VM\ObjectEntry;

--- a/lib/VM/ClassEntry.php
+++ b/lib/VM/ClassEntry.php
@@ -9,6 +9,8 @@
 
 namespace PHPCompiler\VM;
 
+// bug in phan: https://github.com/phan/phan/issues/2661
+// @phan-suppress-next-line PhanUnreferencedUseNormal
 use PHPCompiler\Block;
 
 class ClassEntry {

--- a/lib/VM/ClassProperty.php
+++ b/lib/VM/ClassProperty.php
@@ -9,8 +9,6 @@
 
 namespace PHPCompiler\VM;
 
-use PHPCompiler\Block;
-
 class ClassProperty {
 
     public string $name;

--- a/lib/VM/Context.php
+++ b/lib/VM/Context.php
@@ -12,8 +12,6 @@ namespace PHPCompiler\VM;
 use PHPCompiler\Frame;
 use PHPCompiler\Func;
 use PHPCompiler\Runtime;
-use PHPCompiler\Handler\Builtins;
-use PHPTypes\Type;
 
 class Context {
     public array $functions = [];

--- a/lib/VM/ObjectEntry.php
+++ b/lib/VM/ObjectEntry.php
@@ -9,12 +9,8 @@
 
 namespace PHPCompiler\VM;
 
-use PHPCfg\Func;
-use PHPCfg\Op;
-use PHPCfg\Block as CfgBlock;
-use PHPCfg\Operand;
-use PHPCfg\Script;
-use PHPTypes\Type;
+// Bug in phan: https://github.com/phan/phan/issues/2661
+// @phan-suppress-next-line PhanUnreferencedUseNormal
 use PHPCompiler\Block;
 
 class ObjectEntry {


### PR DESCRIPTION
This removes references to "use" statements that aren't referenced
anywhere in the file and fixes the PhanUnreferencedUseNormal "errors"
that are flagged. For each "use" that was removed, I first checked the
file to verify that there weren't, in fact, any references to them.

There's a bug in phan where it doesn't understand typed property
references as uses, so lines that were only referenced in that way are
simply ignored for now.