### PR TITLE
Fix type incompatiblity errors in memory manager

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -31,8 +31,6 @@ return [
 		'PhanNonClassMethodCall',
 		'PhanUndeclaredTypeReturnType',
 		'PhanUndeclaredVariableDim',
-		'PhanParamSignatureRealMismatchTooManyRequiredParameters',
-		'PhanParamSignatureMismatch',
 		'PhanTypeInvalidDimOffset',
 	],
 ];

--- a/ext/types/strlen.php
+++ b/ext/types/strlen.php
@@ -1,7 +1,7 @@
 <?php
 
-// This file is generated and changes you make will be lost.
-// Change /compiler/ext/types/strlen.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/ext/types/strlen.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code

--- a/lib/JIT.php
+++ b/lib/JIT.php
@@ -1,7 +1,7 @@
 <?php
 
-// This file is generated and changes you make will be lost.
-// Change /compiler/lib/JIT.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code

--- a/lib/JIT/Builtin/Internal.php
+++ b/lib/JIT/Builtin/Internal.php
@@ -1,15 +1,7 @@
 <?php
 
-declare(strict_types=1);
-
-/**
- * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
- *
- * @copyright 2015 Anthony Ferrara. All rights reserved
- * @license MIT See LICENSE at the root of the project for more info
- */
-
-// Change /compiler/lib/JIT/Builtin/Internal.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT/Builtin/Internal.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
@@ -17,13 +9,14 @@ declare(strict_types=1);
  * @copyright 2015 Anthony Ferrara. All rights reserved
  * @license MIT See LICENSE at the root of the project for more info
  */
+
 namespace PHPCompiler\JIT\Builtin;
 
 use PHPCompiler\JIT\Builtin;
 
-class Internal extends Builtin
-{
-    public function register(): void
-    {
+class Internal extends Builtin {
+
+    public function register(): void {
     }
+
 }

--- a/lib/JIT/Builtin/MemoryManager.php
+++ b/lib/JIT/Builtin/MemoryManager.php
@@ -1,15 +1,7 @@
 <?php
 
-declare(strict_types=1);
-
-/**
- * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
- *
- * @copyright 2015 Anthony Ferrara. All rights reserved
- * @license MIT See LICENSE at the root of the project for more info
- */
-
-// Change /compiler/lib/JIT/Builtin/MemoryManager.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT/Builtin/MemoryManager.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
@@ -17,322 +9,341 @@ declare(strict_types=1);
  * @copyright 2015 Anthony Ferrara. All rights reserved
  * @license MIT See LICENSE at the root of the project for more info
  */
+
 namespace PHPCompiler\JIT\Builtin;
 
 use PHPCompiler\JIT\Builtin;
+use PHPCompiler\JIT\Context;
+
 
 use PHPLLVM;
 
-abstract class MemoryManager extends Builtin
-{
-    public function register(): void
-    {
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
-            $this->context->getTypeFromString('int8*'),
-            false,
-            $this->context->getTypeFromString('size_t')
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
-            '__mm__malloc',
-            $fntype___cfcd208495d565ef66e7dff9f98764da
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(
-            \PHPLLVM\Attribute::INDEX_FUNCTION,
-            $this->context->attributes['alwaysinline']
-        );
-
-        $this->context->registerFunction('__mm__malloc', $fn___cfcd208495d565ef66e7dff9f98764da);
-
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
-            $this->context->getTypeFromString('int8*'),
-            false,
-            $this->context->getTypeFromString('int8*'),
-            $this->context->getTypeFromString('size_t')
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
-            '__mm__realloc',
-            $fntype___cfcd208495d565ef66e7dff9f98764da
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(
-            \PHPLLVM\Attribute::INDEX_FUNCTION,
-            $this->context->attributes['alwaysinline']
-        );
-
-        $this->context->registerFunction('__mm__realloc', $fn___cfcd208495d565ef66e7dff9f98764da);
-
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
-            $this->context->getTypeFromString('void'),
-            false,
-            $this->context->getTypeFromString('int8*')
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
-            '__mm__free',
-            $fntype___cfcd208495d565ef66e7dff9f98764da
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(
-            \PHPLLVM\Attribute::INDEX_FUNCTION,
-            $this->context->attributes['alwaysinline']
-        );
-
-        $this->context->registerFunction('__mm__free', $fn___cfcd208495d565ef66e7dff9f98764da);
+abstract class MemoryManager extends Builtin {
+    static public function load(Context $context, int $loadtype) : self {
+        if ($loadtype === Builtin::LOAD_TYPE_STANDALONE) {
+            return new MemoryManager\Native($context, $loadtype);
+        }
+        return new MemoryManager\PHP($context, $loadtype);
     }
 
-    public function malloc(PHPLLVM\Type $type): PHPLLVM\Value
-    {
-        if ($type instanceof \PHPLLVM\Type) {
-            $type = $type;
-        } elseif ($type instanceof \PHPLLVM\Value) {
-            $type = $type->typeOf();
-        } else {
-            throw new \LogicException('Attempt to call sizeof on non-PHPLLVM type/value');
-        }
-        $size = $this->context->builder->ptrToInt(
-            $this->context->builder->gep(
-                $type->pointerType(0)->constNull(),
-                $this->context->context->int32Type()->constInt(1, false)
-            ),
-            $this->context->getTypeFromString('size_t')
-        );
-        $ptr = $this->context->builder->call($this->context->lookupFunction('__mm__malloc'), $size);
+    public function register(): void {
+        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+                $this->context->getTypeFromString('int8*'),
+                false , 
+                $this->context->getTypeFromString('size_t')
+                
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__mm__malloc', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            $this->context->registerFunction('__mm__malloc', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
+        
+
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+                $this->context->getTypeFromString('int8*'),
+                false , 
+                $this->context->getTypeFromString('int8*')
+                , $this->context->getTypeFromString('size_t')
+                
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__mm__realloc', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            
+            $this->context->registerFunction('__mm__realloc', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
+
+        
+
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+                $this->context->getTypeFromString('void'),
+                false , 
+                $this->context->getTypeFromString('int8*')
+                
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__mm__free', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            $this->context->registerFunction('__mm__free', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
+
+        
+
+        
+    
+    }
+
+    public function malloc(PHPLLVM\Type $type): PHPLLVM\Value {
+        if ($type instanceof \PHPLLVM\Type) {
+                        $type = $type;
+                    } elseif ($type instanceof \PHPLLVM\Value) {
+                        $type = $type->typeOf();
+                    } else {
+                        throw new \LogicException("Attempt to call sizeof on non-PHPLLVM type/value");
+                    }
+                    $size = $this->context->builder->ptrToInt(
+                        $this->context->builder->gep(
+                            $type->pointerType(0)->constNull(),
+                            $this->context->context->int32Type()->constInt(1, false)
+                        ),
+                        $this->context->getTypeFromString('size_t')
+                    );
+    $ptr = $this->context->builder->call(
+                        $this->context->lookupFunction('__mm__malloc') , 
+                        $size
+                        
+                    );
+    
         return $this->context->builder->pointerCast($ptr, $type->pointerType(0));
     }
 
-    public function mallocWithExtra(PHPLLVM\Type $type, PHPLLVM\Value $extra): PHPLLVM\Value
-    {
+    public function mallocWithExtra(PHPLLVM\Type $type, PHPLLVM\Value $extra): PHPLLVM\Value {
         if ($type instanceof \PHPLLVM\Type) {
-            $type = $type;
-        } elseif ($type instanceof \PHPLLVM\Value) {
-            $type = $type->typeOf();
-        } else {
-            throw new \LogicException('Attempt to call sizeof on non-PHPLLVM type/value');
-        }
-        $size = $this->context->builder->ptrToInt(
-            $this->context->builder->gep(
-                $type->pointerType(0)->constNull(),
-                $this->context->context->int32Type()->constInt(1, false)
-            ),
-            $this->context->getTypeFromString('size_t')
-        );
-        $__right = $this->context->builder->intCast($extra, $size->typeOf());
+                        $type = $type;
+                    } elseif ($type instanceof \PHPLLVM\Value) {
+                        $type = $type->typeOf();
+                    } else {
+                        throw new \LogicException("Attempt to call sizeof on non-PHPLLVM type/value");
+                    }
+                    $size = $this->context->builder->ptrToInt(
+                        $this->context->builder->gep(
+                            $type->pointerType(0)->constNull(),
+                            $this->context->context->int32Type()->constInt(1, false)
+                        ),
+                        $this->context->getTypeFromString('size_t')
+                    );
+    $__right = $this->context->builder->intCast($extra, $size->typeOf());
+                            
+                            
+                        
 
-        $size = $this->context->builder->addNoUnsignedWrap($size, $__right);
-        $ptr = $this->context->builder->call($this->context->lookupFunction('__mm__malloc'), $size);
+                        
 
+                        
+
+                        
+
+                        $size = $this->context->builder->addNoUnsignedWrap($size, $__right);
+    $ptr = $this->context->builder->call(
+                        $this->context->lookupFunction('__mm__malloc') , 
+                        $size
+                        
+                    );
+    
         return $this->context->builder->pointerCast($ptr, $type->pointerType(0));
     }
 
-    public function realloc(PHPLLVM\Value $value, PHPLLVM\Value $extra): PHPLLVM\Value
-    {
+    public function realloc(PHPLLVM\Value $value, PHPLLVM\Value $extra): PHPLLVM\Value {
         $type = $value->typeOf()->getElementType();
         if ($type instanceof \PHPLLVM\Type) {
-            $type = $type;
-        } elseif ($type instanceof \PHPLLVM\Value) {
-            $type = $type->typeOf();
-        } else {
-            throw new \LogicException('Attempt to call sizeof on non-PHPLLVM type/value');
-        }
-        $size = $this->context->builder->ptrToInt(
-            $this->context->builder->gep(
-                $type->pointerType(0)->constNull(),
-                $this->context->context->int32Type()->constInt(1, false)
-            ),
-            $this->context->getTypeFromString('size_t')
-        );
-        $__right = $this->context->builder->intCast($extra, $size->typeOf());
+                        $type = $type;
+                    } elseif ($type instanceof \PHPLLVM\Value) {
+                        $type = $type->typeOf();
+                    } else {
+                        throw new \LogicException("Attempt to call sizeof on non-PHPLLVM type/value");
+                    }
+                    $size = $this->context->builder->ptrToInt(
+                        $this->context->builder->gep(
+                            $type->pointerType(0)->constNull(),
+                            $this->context->context->int32Type()->constInt(1, false)
+                        ),
+                        $this->context->getTypeFromString('size_t')
+                    );
+    $__right = $this->context->builder->intCast($extra, $size->typeOf());
+                            
+                            
+                        
 
-        $allocSize = $this->context->builder->addNoUnsignedWrap($size, $__right);
-        $__type = $this->context->getTypeFromString('int8*');
+                        
 
-        $__kind = $__type->getKind();
-        $__value = $value;
-        switch ($__kind) {
-            case \PHPLLVM\Type::KIND_INTEGER:
-                if (! is_object($__value)) {
-                    $void = $__type->constInt($__value, false);
+                        
 
-                    break;
-                }
-                $__other_type = $__value->typeOf();
-                switch ($__other_type->getKind()) {
-                    case \PHPLLVM\Type::KIND_INTEGER:
-                        if ($__other_type->getWidth() >= $__type->getWidth()) {
-                            $void = $this->context->builder->truncOrBitCast($__value, $__type);
-                        } else {
-                            $void = $this->context->builder->zExtOrBitCast($__value, $__type);
-                        }
+                        
 
-                        break;
-                    case \PHPLLVM\Type::KIND_DOUBLE:
-                        $void = $this->context->builder->fpToUi($__value, $__type);
-
-                        break;
-                    case \PHPLLVM\Type::KIND_ARRAY:
-                    case \PHPLLVM\Type::KIND_POINTER:
-                        $void = $this->context->builder->ptrToInt($__value, $__type);
-
-                        break;
-                    default:
-                        throw new \LogicException(
-                            'Unknown how to handle type pair (int, '.$__other_type->toString().')'
-                        );
-                }
-
-                break;
-            case \PHPLLVM\Type::KIND_DOUBLE:
-                if (! is_object($__value)) {
-                    $void = $__type->constReal($value);
-
-                    break;
-                }
-                $__other_type = $__value->typeOf();
-                switch ($__other_type->getKind()) {
-                    case \PHPLLVM\Type::KIND_INTEGER:
-                        $void = $this->context->builder->uiToFp($__value, $__type);
-
-                        break;
-                    case \PHPLLVM\Type::KIND_DOUBLE:
-                        $void = $this->context->builder->fpCast($__value, $__type);
-
-                        break;
-                    default:
-                        throw new \LogicException(
-                            'Unknown how to handle type pair (double, '.$__other_type->toString().')'
-                        );
-                }
-
-                break;
-            case \PHPLLVM\Type::KIND_ARRAY:
-            case \PHPLLVM\Type::KIND_POINTER:
-                if (! is_object($__value)) {
-                    // this is very likely very wrong...
-                    $void = $__type->constInt($__value, false);
-
-                    break;
-                }
-                $__other_type = $__value->typeOf();
-                switch ($__other_type->getKind()) {
-                    case \PHPLLVM\Type::KIND_INTEGER:
-                        $void = $this->context->builder->intToPtr($__value, $__type);
-
-                        break;
-                    case \PHPLLVM\Type::KIND_ARRAY:
-                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
-                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
-                    // break;
-                    case \PHPLLVM\Type::KIND_POINTER:
-                        $void = $this->context->builder->pointerCast($__value, $__type);
-
-                        break;
-                    default:
-                        throw new \LogicException(
-                            'Unknown how to handle type pair (double, '.$__other_type->toString().')'
-                        );
-                }
-
-                break;
-            default:
-                throw new \LogicException('Unsupported type cast: '.$__type->toString());
-        }
-        $ptr = $this->context->builder->call($this->context->lookupFunction('__mm__realloc'), $void, $allocSize);
-
+                        $allocSize = $this->context->builder->addNoUnsignedWrap($size, $__right);
+    $__type = $this->context->getTypeFromString('int8*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $value;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
+                                $void = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $void = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $void = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $void = $this->context->builder->fpToUi($__value, $__type);
+                                    
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $void = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $void = $__type->constReal($value);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $void = $this->context->builder->uiToFp($__value, $__type);
+                                    
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $void = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $void = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $void = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $void = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    $ptr = $this->context->builder->call(
+                        $this->context->lookupFunction('__mm__realloc') , 
+                        $void
+                        , $allocSize
+                        
+                    );
+    
         return $this->context->builder->pointerCast($ptr, $type->pointerType(0));
     }
 
-    public function free(PHPLLVM\Value $value): void
-    {
+    public function free(PHPLLVM\Value $value): void {
         $__type = $this->context->getTypeFromString('int8*');
-
-        $__kind = $__type->getKind();
-        $__value = $value;
-        switch ($__kind) {
-            case \PHPLLVM\Type::KIND_INTEGER:
-                if (! is_object($__value)) {
-                    $void = $__type->constInt($__value, false);
-
-                    break;
-                }
-                $__other_type = $__value->typeOf();
-                switch ($__other_type->getKind()) {
-                    case \PHPLLVM\Type::KIND_INTEGER:
-                        if ($__other_type->getWidth() >= $__type->getWidth()) {
-                            $void = $this->context->builder->truncOrBitCast($__value, $__type);
-                        } else {
-                            $void = $this->context->builder->zExtOrBitCast($__value, $__type);
-                        }
-
-                        break;
-                    case \PHPLLVM\Type::KIND_DOUBLE:
-                        $void = $this->context->builder->fpToSi($__value, $__type);
-
-                        break;
-                    case \PHPLLVM\Type::KIND_ARRAY:
-                    case \PHPLLVM\Type::KIND_POINTER:
-                        $void = $this->context->builder->ptrToInt($__value, $__type);
-
-                        break;
-                    default:
-                        throw new \LogicException(
-                            'Unknown how to handle type pair (int, '.$__other_type->toString().')'
-                        );
-                }
-
-                break;
-            case \PHPLLVM\Type::KIND_DOUBLE:
-                if (! is_object($__value)) {
-                    $void = $__type->constReal($value);
-
-                    break;
-                }
-                $__other_type = $__value->typeOf();
-                switch ($__other_type->getKind()) {
-                    case \PHPLLVM\Type::KIND_INTEGER:
-                        $void = $this->context->builder->siToFp($__value, $__type);
-
-                        break;
-                    case \PHPLLVM\Type::KIND_DOUBLE:
-                        $void = $this->context->builder->fpCast($__value, $__type);
-
-                        break;
-                    default:
-                        throw new \LogicException(
-                            'Unknown how to handle type pair (double, '.$__other_type->toString().')'
-                        );
-                }
-
-                break;
-            case \PHPLLVM\Type::KIND_ARRAY:
-            case \PHPLLVM\Type::KIND_POINTER:
-                if (! is_object($__value)) {
-                    // this is very likely very wrong...
-                    $void = $__type->constInt($__value, false);
-
-                    break;
-                }
-                $__other_type = $__value->typeOf();
-                switch ($__other_type->getKind()) {
-                    case \PHPLLVM\Type::KIND_INTEGER:
-                        $void = $this->context->builder->intToPtr($__value, $__type);
-
-                        break;
-                    case \PHPLLVM\Type::KIND_ARRAY:
-                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
-                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
-                    // break;
-                    case \PHPLLVM\Type::KIND_POINTER:
-                        $void = $this->context->builder->pointerCast($__value, $__type);
-
-                        break;
-                    default:
-                        throw new \LogicException(
-                            'Unknown how to handle type pair (double, '.$__other_type->toString().')'
-                        );
-                }
-
-                break;
-            default:
-                throw new \LogicException('Unsupported type cast: '.$__type->toString());
-        }
-        $this->context->builder->call($this->context->lookupFunction('__mm__free'), $void);
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $value;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
+                                $void = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $void = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $void = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    
+                                    $void = $this->context->builder->fpToSi($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $void = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $void = $__type->constReal($value);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    
+                                    $void = $this->context->builder->siToFp($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $void = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $void = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $void = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $void = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    $this->context->builder->call(
+                    $this->context->lookupFunction('__mm__free') , 
+                    $void
+                    
+                );
+    
     }
+
 }

--- a/lib/JIT/Builtin/MemoryManager.pre
+++ b/lib/JIT/Builtin/MemoryManager.pre
@@ -10,10 +10,18 @@
 namespace PHPCompiler\JIT\Builtin;
 
 use PHPCompiler\JIT\Builtin;
+use PHPCompiler\JIT\Context;
+
 
 use PHPLLVM;
 
 abstract class MemoryManager extends Builtin {
+    static public function load(Context $context, int $loadtype) : self {
+        if ($loadtype === Builtin::LOAD_TYPE_STANDALONE) {
+            return new MemoryManager\Native($context, $loadtype);
+        }
+        return new MemoryManager\PHP($context, $loadtype);
+    }
 
     public function register(): void {
         declare {

--- a/lib/JIT/Builtin/MemoryManager/Native.php
+++ b/lib/JIT/Builtin/MemoryManager/Native.php
@@ -1,15 +1,7 @@
 <?php
 
-declare(strict_types=1);
-
-/**
- * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
- *
- * @copyright 2015 Anthony Ferrara. All rights reserved
- * @license MIT See LICENSE at the root of the project for more info
- */
-
-// Change /compiler/lib/JIT/Builtin/MemoryManager/Native.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT/Builtin/MemoryManager/Native.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
@@ -17,83 +9,111 @@ declare(strict_types=1);
  * @copyright 2015 Anthony Ferrara. All rights reserved
  * @license MIT See LICENSE at the root of the project for more info
  */
+
 namespace PHPCompiler\JIT\Builtin\MemoryManager;
 
 use PHPCompiler\JIT\Builtin\MemoryManager;
 
-class Native extends MemoryManager
-{
-    public function register(): void
-    {
+class Native extends MemoryManager {
+
+    public function register(): void {
         parent::register();
         $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
-            $this->context->getTypeFromString('int8*'),
-            false,
-            $this->context->getTypeFromString('size_t')
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
-            'malloc',
-            $fntype___cfcd208495d565ef66e7dff9f98764da
-        );
+                $this->context->getTypeFromString('int8*'),
+                false , 
+                $this->context->getTypeFromString('size_t')
+                
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('malloc', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            
+            
+            
+            $this->context->registerFunction('malloc', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('malloc', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
-            $this->context->getTypeFromString('int8*'),
-            false,
-            $this->context->getTypeFromString('int8*'),
-            $this->context->getTypeFromString('size_t')
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
-            'realloc',
-            $fntype___cfcd208495d565ef66e7dff9f98764da
-        );
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+                $this->context->getTypeFromString('int8*'),
+                false , 
+                $this->context->getTypeFromString('int8*')
+                , $this->context->getTypeFromString('size_t')
+                
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('realloc', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            
+            
+            
+            
+            $this->context->registerFunction('realloc', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('realloc', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
-            $this->context->getTypeFromString('void'),
-            false,
-            $this->context->getTypeFromString('int8*')
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
-            'free',
-            $fntype___cfcd208495d565ef66e7dff9f98764da
-        );
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+                $this->context->getTypeFromString('void'),
+                false , 
+                $this->context->getTypeFromString('int8*')
+                
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('free', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            
+            
+            
+            $this->context->registerFunction('free', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('free', $fn___cfcd208495d565ef66e7dff9f98764da);
-    }
+        
 
-    public function implement(): void
-    {
+        
+    
+    } 
+
+    public function implement(): void {
         // Todo
         $fn___c4ca4238a0b923820dcc509a6f75849b = $this->context->lookupFunction('__mm__malloc');
-        $block___c4ca4238a0b923820dcc509a6f75849b = $fn___c4ca4238a0b923820dcc509a6f75849b->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___c4ca4238a0b923820dcc509a6f75849b);
-        $size = $fn___c4ca4238a0b923820dcc509a6f75849b->getParam(0);
-
-        $result = $this->context->builder->call($this->context->lookupFunction('malloc'), $size);
-        $this->context->builder->returnValue($result);
-
-        $this->context->builder->clearInsertionPosition();
+    $block___c4ca4238a0b923820dcc509a6f75849b = $fn___c4ca4238a0b923820dcc509a6f75849b->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___c4ca4238a0b923820dcc509a6f75849b);
+    $size = $fn___c4ca4238a0b923820dcc509a6f75849b->getParam(0);
+    
+    $result = $this->context->builder->call(
+                        $this->context->lookupFunction('malloc') , 
+                        $size
+                        
+                    );
+    $this->context->builder->returnValue($result);
+    
+    $this->context->builder->clearInsertionPosition();
         $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3 = $this->context->lookupFunction('__mm__realloc');
-        $block___eccbc87e4b5ce2fe28308fd9f2a7baf3 = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___eccbc87e4b5ce2fe28308fd9f2a7baf3);
-        $void = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->getParam(0);
-        $size = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->getParam(1);
-
-        $result = $this->context->builder->call($this->context->lookupFunction('realloc'), $void, $size);
-        $this->context->builder->returnValue($result);
-
-        $this->context->builder->clearInsertionPosition();
+    $block___eccbc87e4b5ce2fe28308fd9f2a7baf3 = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___eccbc87e4b5ce2fe28308fd9f2a7baf3);
+    $void = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->getParam(0);
+    $size = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->getParam(1);
+    
+    $result = $this->context->builder->call(
+                        $this->context->lookupFunction('realloc') , 
+                        $void
+                        , $size
+                        
+                    );
+    $this->context->builder->returnValue($result);
+    
+    $this->context->builder->clearInsertionPosition();
         $fn___e4da3b7fbbce2345d7772b0674a318d5 = $this->context->lookupFunction('__mm__free');
-        $block___e4da3b7fbbce2345d7772b0674a318d5 = $fn___e4da3b7fbbce2345d7772b0674a318d5->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___e4da3b7fbbce2345d7772b0674a318d5);
-        $void = $fn___e4da3b7fbbce2345d7772b0674a318d5->getParam(0);
-
-        $this->context->builder->call($this->context->lookupFunction('free'), $void);
-        $this->context->builder->returnVoid();
-
-        $this->context->builder->clearInsertionPosition();
+    $block___e4da3b7fbbce2345d7772b0674a318d5 = $fn___e4da3b7fbbce2345d7772b0674a318d5->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___e4da3b7fbbce2345d7772b0674a318d5);
+    $void = $fn___e4da3b7fbbce2345d7772b0674a318d5->getParam(0);
+    
+    $this->context->builder->call(
+                    $this->context->lookupFunction('free') , 
+                    $void
+                    
+                );
+    $this->context->builder->returnVoid();
+    
+    $this->context->builder->clearInsertionPosition();
     }
+
 }

--- a/lib/JIT/Builtin/MemoryManager/PHP.php
+++ b/lib/JIT/Builtin/MemoryManager/PHP.php
@@ -1,8 +1,9 @@
 <?php
 
-declare(strict_types=1);
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT/Builtin/MemoryManager/PHP.pre instead.
 
-/**
+/*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
  *
  * @copyright 2015 Anthony Ferrara. All rights reserved
@@ -13,120 +14,256 @@ namespace PHPCompiler\JIT\Builtin\MemoryManager;
 
 use PHPCompiler\JIT\Builtin\MemoryManager;
 
-class PHP extends MemoryManager
-{
-    public function register(): void
-    {
+class PHP extends MemoryManager {
+    public function register(): void {
         parent::register();
-        $this->context->helper->importFunction(
-            '_efree',
-            'void',
-            false,
-            'void*',
-            ...$this->expandDebugDecl()
-        );
-        $this->context->helper->importfunction(
-            '_emalloc',
-            'void*',
-            false,
-            'size_t',
-            ...$this->expandDebugDecl()
-        );
-        $this->context->helper->importFunction(
-            '_erealloc',
-            'void*',
-            false,
-            'void*',
-            'size_t',
-            ...$this->expandDebugDecl()
-        );
-    }
-
-    /*
-    public function malloc(\gcc_jit_rvalue_ptr $size, \gcc_jit_type_ptr $type): \gcc_jit_rvalue_ptr
-    {
-        $void = $this->context->helper->call(
-            '_emalloc',
-            $size,
-            ...$this->expandDebugArgs()
-        );
-
-        return \gcc_jit_context_new_cast(
-            $this->context->context,
-            null,
-            $void,
-            $type
-        );
-    }
-
-    public function realloc(\gcc_jit_rvalue_ptr $ptr, \gcc_jit_rvalue_ptr $size, \gcc_jit_type_ptr $type): \gcc_jit_rvalue_ptr
-    {
-        $void = $this->context->helper->call(
-            '_erealloc',
-            \gcc_jit_context_new_cast(
-                $this->context->context,
-                $this->context->location(),
-                $ptr,
-                $this->context->getTypeFromString('void*')
-            ),
-            $size,
-            ...$this->expandDebugArgs()
-        );
-
-        return \gcc_jit_context_new_cast(
-            $this->context->context,
-            null,
-            $void,
-            $type
-        );
-    }
-
-    public function free(
-        \gcc_jit_block_ptr $block,
-        \gcc_jit_rvalue_ptr $ptr
-    ): void {
-        $this->context->helper->eval(
-            $block,
-            $this->context->helper->call(
-                '_efree',
-                $this->context->helper->cast($ptr, 'void*'),
-                ...$this->expandDebugArgs()
-            )
-        );
-    }
-
-     */
-    private function expandDebugDecl(): array
-    {
         if (\PHP_DEBUG) {
-            return [
-                'const char*',
-                'uint32_t',
-                'const char*',
-                'uint32_t',
-            ];
-        }
+            $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+                $this->context->getTypeFromString('int8*'),
+                false , 
+                $this->context->getTypeFromString('size_t')
+                , $this->context->getTypeFromString('char*')
+                , $this->context->getTypeFromString('uint32')
+                , $this->context->getTypeFromString('char*')
+                , $this->context->getTypeFromString('uint32')
+                
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('_emalloc', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            
+            
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(1 + 1, $this->context->attributes['readonly'], 0);
+                    $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(1 + 1, $this->context->attributes['nocapture'], 0);
+                
+            
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(3 + 1, $this->context->attributes['readonly'], 0);
+                    $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(3 + 1, $this->context->attributes['nocapture'], 0);
+                
+            
+            
+            $this->context->registerFunction('_emalloc', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        return [];
+        
+
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+                $this->context->getTypeFromString('int8*'),
+                false , 
+                $this->context->getTypeFromString('int8*')
+                , $this->context->getTypeFromString('size_t')
+                , $this->context->getTypeFromString('char*')
+                , $this->context->getTypeFromString('uint32')
+                , $this->context->getTypeFromString('char*')
+                , $this->context->getTypeFromString('uint32')
+                
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('_erealloc', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            
+            
+            
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(2 + 1, $this->context->attributes['readonly'], 0);
+                    $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(2 + 1, $this->context->attributes['nocapture'], 0);
+                
+            
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(4 + 1, $this->context->attributes['readonly'], 0);
+                    $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(4 + 1, $this->context->attributes['nocapture'], 0);
+                
+            
+            
+            $this->context->registerFunction('_erealloc', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
+
+        
+
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+                $this->context->getTypeFromString('void'),
+                false , 
+                $this->context->getTypeFromString('int8*')
+                , $this->context->getTypeFromString('char*')
+                , $this->context->getTypeFromString('uint32')
+                , $this->context->getTypeFromString('char*')
+                , $this->context->getTypeFromString('uint32')
+                
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('_efree', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            
+            
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(1 + 1, $this->context->attributes['readonly'], 0);
+                    $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(1 + 1, $this->context->attributes['nocapture'], 0);
+                
+            
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(3 + 1, $this->context->attributes['readonly'], 0);
+                    $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(3 + 1, $this->context->attributes['nocapture'], 0);
+                
+            
+            
+            $this->context->registerFunction('_efree', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
+
+        
+
+        
+    
+        } else {
+           $fntype___c4ca4238a0b923820dcc509a6f75849b = $this->context->context->functionType(
+                $this->context->getTypeFromString('int8*'),
+                false , 
+                $this->context->getTypeFromString('size_t')
+                
+            );
+            $fn___c4ca4238a0b923820dcc509a6f75849b = $this->context->module->addFunction('_emalloc', $fntype___c4ca4238a0b923820dcc509a6f75849b);
+            
+            
+            
+            $this->context->registerFunction('_emalloc', $fn___c4ca4238a0b923820dcc509a6f75849b);
+        
+
+        
+
+        
+    $fntype___c4ca4238a0b923820dcc509a6f75849b = $this->context->context->functionType(
+                $this->context->getTypeFromString('int8*'),
+                false , 
+                $this->context->getTypeFromString('int8*')
+                , $this->context->getTypeFromString('size_t')
+                
+            );
+            $fn___c4ca4238a0b923820dcc509a6f75849b = $this->context->module->addFunction('_erealloc', $fntype___c4ca4238a0b923820dcc509a6f75849b);
+            
+            
+            
+            
+            $this->context->registerFunction('_erealloc', $fn___c4ca4238a0b923820dcc509a6f75849b);
+        
+
+        
+
+        
+    $fntype___c4ca4238a0b923820dcc509a6f75849b = $this->context->context->functionType(
+                $this->context->getTypeFromString('void'),
+                false , 
+                $this->context->getTypeFromString('int8*')
+                
+            );
+            $fn___c4ca4238a0b923820dcc509a6f75849b = $this->context->module->addFunction('_efree', $fntype___c4ca4238a0b923820dcc509a6f75849b);
+            
+            
+            
+            $this->context->registerFunction('_efree', $fn___c4ca4238a0b923820dcc509a6f75849b);
+        
+
+        
+
+        
+    
+        }
     }
 
-    private function expandDebugArgs(): array
-    {
+    public function implement(): void {
         if (\PHP_DEBUG) {
-            return [
-                $this->context->constantFromString('jit'),
-                $this->context->helper->cast(
-                    $this->context->constantFromInteger(2),
-                    'uint32_t'
-                ),
-                $this->context->constantFromString('jit'),
-                $this->context->helper->cast(
-                    $this->context->constantFromInteger(2),
-                    'uint32_t'
-                ),
-            ];
-        }
+            // FIXME: Use real values here, not constants.
 
-        return [];
+            // These variables are a hack because compile{}
+            // blocks currently only accept variables as arguments.
+            $jit = $this->context->constantFromString("jit");
+            $two = 2;
+
+            $fn___c81e728d9d4c2f636f067f89cc14862c = $this->context->lookupFunction('__mm__malloc');
+    $block___c81e728d9d4c2f636f067f89cc14862c = $fn___c81e728d9d4c2f636f067f89cc14862c->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___c81e728d9d4c2f636f067f89cc14862c);
+    $size = $fn___c81e728d9d4c2f636f067f89cc14862c->getParam(0);
+    
+    $result = $this->context->builder->call(
+                        $this->context->lookupFunction('_emalloc') , 
+                        $size
+                        , $jit
+                        , $two
+                        , $jit
+                        , $two
+                        
+                    );
+    $this->context->builder->returnValue($result);
+    
+    $this->context->builder->clearInsertionPosition();
+            $fn___a87ff679a2f3e71d9181a67b7542122c = $this->context->lookupFunction('__mm__realloc');
+    $block___a87ff679a2f3e71d9181a67b7542122c = $fn___a87ff679a2f3e71d9181a67b7542122c->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___a87ff679a2f3e71d9181a67b7542122c);
+    $void = $fn___a87ff679a2f3e71d9181a67b7542122c->getParam(0);
+    $size = $fn___a87ff679a2f3e71d9181a67b7542122c->getParam(1);
+    
+    $result = $this->context->builder->call(
+                        $this->context->lookupFunction('_erealloc') , 
+                        $void
+                        , $size
+                        , $jit
+                        , $two
+                        , $jit
+                        , $two
+                        
+                    );
+    $this->context->builder->returnValue($result);
+    
+    $this->context->builder->clearInsertionPosition();
+            $fn___1679091c5a880faf6fb5e6087eb1b2dc = $this->context->lookupFunction('__mm__free');
+    $block___1679091c5a880faf6fb5e6087eb1b2dc = $fn___1679091c5a880faf6fb5e6087eb1b2dc->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___1679091c5a880faf6fb5e6087eb1b2dc);
+    $void = $fn___1679091c5a880faf6fb5e6087eb1b2dc->getParam(0);
+    
+    $this->context->builder->call(
+                    $this->context->lookupFunction('_efree') , 
+                    $void
+                    , $jit
+                    , $two
+                    , $jit
+                    , $two
+                    
+                );
+    $this->context->builder->returnVoid();
+    
+    $this->context->builder->clearInsertionPosition();
+        } else {
+            $fn___c9f0f895fb98ab9159f51fd0297e236d = $this->context->lookupFunction('__mm__malloc');
+    $block___c9f0f895fb98ab9159f51fd0297e236d = $fn___c9f0f895fb98ab9159f51fd0297e236d->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___c9f0f895fb98ab9159f51fd0297e236d);
+    $size = $fn___c9f0f895fb98ab9159f51fd0297e236d->getParam(0);
+    
+    $result = $this->context->builder->call(
+                        $this->context->lookupFunction('_emalloc') , 
+                        $size
+                        
+                    );
+    $this->context->builder->returnValue($result);
+    
+    $this->context->builder->clearInsertionPosition();
+            $fn___d3d9446802a44259755d38e6d163e820 = $this->context->lookupFunction('__mm__realloc');
+    $block___d3d9446802a44259755d38e6d163e820 = $fn___d3d9446802a44259755d38e6d163e820->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___d3d9446802a44259755d38e6d163e820);
+    $void = $fn___d3d9446802a44259755d38e6d163e820->getParam(0);
+    $size = $fn___d3d9446802a44259755d38e6d163e820->getParam(1);
+    
+    $result = $this->context->builder->call(
+                        $this->context->lookupFunction('_erealloc') , 
+                        $void
+                        , $size
+                        
+                    );
+    $this->context->builder->returnValue($result);
+    
+    $this->context->builder->clearInsertionPosition();
+            $fn___c20ad4d76fe97759aa27a0c99bff6710 = $this->context->lookupFunction('__mm__free');
+    $block___c20ad4d76fe97759aa27a0c99bff6710 = $fn___c20ad4d76fe97759aa27a0c99bff6710->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___c20ad4d76fe97759aa27a0c99bff6710);
+    $void = $fn___c20ad4d76fe97759aa27a0c99bff6710->getParam(0);
+    
+    $this->context->builder->call(
+                    $this->context->lookupFunction('_efree') , 
+                    $void
+                    
+                );
+    $this->context->builder->returnVoid();
+    
+    $this->context->builder->clearInsertionPosition();
+        }
     }
 }

--- a/lib/JIT/Builtin/MemoryManager/PHP.php
+++ b/lib/JIT/Builtin/MemoryManager/PHP.php
@@ -167,12 +167,90 @@ class PHP extends MemoryManager {
             // These variables are a hack because compile{}
             // blocks currently only accept variables as arguments.
             $jit = $this->context->constantFromString("jit");
-            $two = 2;
+            $__type = $this->context->getTypeFromString('int32');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = 2;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
+                                $two = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $two = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $two = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    
+                                    $two = $this->context->builder->fpToSi($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $two = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $two = $__type->constReal(2);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    
+                                    $two = $this->context->builder->siToFp($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $two = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $two = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $two = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $two = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    
 
-            $fn___c81e728d9d4c2f636f067f89cc14862c = $this->context->lookupFunction('__mm__malloc');
-    $block___c81e728d9d4c2f636f067f89cc14862c = $fn___c81e728d9d4c2f636f067f89cc14862c->appendBasicBlock('main');
-    $this->context->builder->positionAtEnd($block___c81e728d9d4c2f636f067f89cc14862c);
-    $size = $fn___c81e728d9d4c2f636f067f89cc14862c->getParam(0);
+            $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3 = $this->context->lookupFunction('__mm__malloc');
+    $block___eccbc87e4b5ce2fe28308fd9f2a7baf3 = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___eccbc87e4b5ce2fe28308fd9f2a7baf3);
+    $size = $fn___eccbc87e4b5ce2fe28308fd9f2a7baf3->getParam(0);
     
     $result = $this->context->builder->call(
                         $this->context->lookupFunction('_emalloc') , 
@@ -186,11 +264,11 @@ class PHP extends MemoryManager {
     $this->context->builder->returnValue($result);
     
     $this->context->builder->clearInsertionPosition();
-            $fn___a87ff679a2f3e71d9181a67b7542122c = $this->context->lookupFunction('__mm__realloc');
-    $block___a87ff679a2f3e71d9181a67b7542122c = $fn___a87ff679a2f3e71d9181a67b7542122c->appendBasicBlock('main');
-    $this->context->builder->positionAtEnd($block___a87ff679a2f3e71d9181a67b7542122c);
-    $void = $fn___a87ff679a2f3e71d9181a67b7542122c->getParam(0);
-    $size = $fn___a87ff679a2f3e71d9181a67b7542122c->getParam(1);
+            $fn___e4da3b7fbbce2345d7772b0674a318d5 = $this->context->lookupFunction('__mm__realloc');
+    $block___e4da3b7fbbce2345d7772b0674a318d5 = $fn___e4da3b7fbbce2345d7772b0674a318d5->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___e4da3b7fbbce2345d7772b0674a318d5);
+    $void = $fn___e4da3b7fbbce2345d7772b0674a318d5->getParam(0);
+    $size = $fn___e4da3b7fbbce2345d7772b0674a318d5->getParam(1);
     
     $result = $this->context->builder->call(
                         $this->context->lookupFunction('_erealloc') , 
@@ -205,10 +283,10 @@ class PHP extends MemoryManager {
     $this->context->builder->returnValue($result);
     
     $this->context->builder->clearInsertionPosition();
-            $fn___1679091c5a880faf6fb5e6087eb1b2dc = $this->context->lookupFunction('__mm__free');
-    $block___1679091c5a880faf6fb5e6087eb1b2dc = $fn___1679091c5a880faf6fb5e6087eb1b2dc->appendBasicBlock('main');
-    $this->context->builder->positionAtEnd($block___1679091c5a880faf6fb5e6087eb1b2dc);
-    $void = $fn___1679091c5a880faf6fb5e6087eb1b2dc->getParam(0);
+            $fn___8f14e45fceea167a5a36dedd4bea2543 = $this->context->lookupFunction('__mm__free');
+    $block___8f14e45fceea167a5a36dedd4bea2543 = $fn___8f14e45fceea167a5a36dedd4bea2543->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___8f14e45fceea167a5a36dedd4bea2543);
+    $void = $fn___8f14e45fceea167a5a36dedd4bea2543->getParam(0);
     
     $this->context->builder->call(
                     $this->context->lookupFunction('_efree') , 
@@ -223,10 +301,10 @@ class PHP extends MemoryManager {
     
     $this->context->builder->clearInsertionPosition();
         } else {
-            $fn___c9f0f895fb98ab9159f51fd0297e236d = $this->context->lookupFunction('__mm__malloc');
-    $block___c9f0f895fb98ab9159f51fd0297e236d = $fn___c9f0f895fb98ab9159f51fd0297e236d->appendBasicBlock('main');
-    $this->context->builder->positionAtEnd($block___c9f0f895fb98ab9159f51fd0297e236d);
-    $size = $fn___c9f0f895fb98ab9159f51fd0297e236d->getParam(0);
+            $fn___45c48cce2e2d7fbdea1afc51c7c6ad26 = $this->context->lookupFunction('__mm__malloc');
+    $block___45c48cce2e2d7fbdea1afc51c7c6ad26 = $fn___45c48cce2e2d7fbdea1afc51c7c6ad26->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___45c48cce2e2d7fbdea1afc51c7c6ad26);
+    $size = $fn___45c48cce2e2d7fbdea1afc51c7c6ad26->getParam(0);
     
     $result = $this->context->builder->call(
                         $this->context->lookupFunction('_emalloc') , 
@@ -236,11 +314,11 @@ class PHP extends MemoryManager {
     $this->context->builder->returnValue($result);
     
     $this->context->builder->clearInsertionPosition();
-            $fn___d3d9446802a44259755d38e6d163e820 = $this->context->lookupFunction('__mm__realloc');
-    $block___d3d9446802a44259755d38e6d163e820 = $fn___d3d9446802a44259755d38e6d163e820->appendBasicBlock('main');
-    $this->context->builder->positionAtEnd($block___d3d9446802a44259755d38e6d163e820);
-    $void = $fn___d3d9446802a44259755d38e6d163e820->getParam(0);
-    $size = $fn___d3d9446802a44259755d38e6d163e820->getParam(1);
+            $fn___6512bd43d9caa6e02c990b0a82652dca = $this->context->lookupFunction('__mm__realloc');
+    $block___6512bd43d9caa6e02c990b0a82652dca = $fn___6512bd43d9caa6e02c990b0a82652dca->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___6512bd43d9caa6e02c990b0a82652dca);
+    $void = $fn___6512bd43d9caa6e02c990b0a82652dca->getParam(0);
+    $size = $fn___6512bd43d9caa6e02c990b0a82652dca->getParam(1);
     
     $result = $this->context->builder->call(
                         $this->context->lookupFunction('_erealloc') , 
@@ -251,10 +329,10 @@ class PHP extends MemoryManager {
     $this->context->builder->returnValue($result);
     
     $this->context->builder->clearInsertionPosition();
-            $fn___c20ad4d76fe97759aa27a0c99bff6710 = $this->context->lookupFunction('__mm__free');
-    $block___c20ad4d76fe97759aa27a0c99bff6710 = $fn___c20ad4d76fe97759aa27a0c99bff6710->appendBasicBlock('main');
-    $this->context->builder->positionAtEnd($block___c20ad4d76fe97759aa27a0c99bff6710);
-    $void = $fn___c20ad4d76fe97759aa27a0c99bff6710->getParam(0);
+            $fn___c51ce410c124a10e0db5e4b97fc2af39 = $this->context->lookupFunction('__mm__free');
+    $block___c51ce410c124a10e0db5e4b97fc2af39 = $fn___c51ce410c124a10e0db5e4b97fc2af39->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___c51ce410c124a10e0db5e4b97fc2af39);
+    $void = $fn___c51ce410c124a10e0db5e4b97fc2af39->getParam(0);
     
     $this->context->builder->call(
                     $this->context->lookupFunction('_efree') , 

--- a/lib/JIT/Builtin/MemoryManager/PHP.pre
+++ b/lib/JIT/Builtin/MemoryManager/PHP.pre
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
+ *
+ * @copyright 2015 Anthony Ferrara. All rights reserved
+ * @license MIT See LICENSE at the root of the project for more info
+ */
+
+namespace PHPCompiler\JIT\Builtin\MemoryManager;
+
+use PHPCompiler\JIT\Builtin\MemoryManager;
+
+class PHP extends MemoryManager {
+    public function register(): void {
+        parent::register();
+        if (\PHP_DEBUG) {
+            declare {
+                function _emalloc(size_t, const char*, uint32, const char*, uint32): int8*;
+                function _erealloc(int8*, size_t, const char*, uint32, const char*, uint32): int8*;
+                function _efree(int8*, const char*, uint32, const char*, uint32): void;
+            }
+        } else {
+           declare {
+                function _emalloc(size_t): int8*;
+                function _erealloc(int8*, size_t): int8*;
+                function _efree(int8*): void;
+           }
+        }
+    }
+
+    public function implement(): void {
+        if (\PHP_DEBUG) {
+            // FIXME: Use real values here, not constants.
+
+            // These variables are a hack because compile{}
+            // blocks currently only accept variables as arguments.
+            $jit = $this->context->constantFromString("jit");
+            $two = 2;
+
+            compile {
+                function __mm__malloc($size) {
+                    $result = _emalloc($size, $jit, $two, $jit, $two);
+                    return $result;
+                }
+            }
+            compile {
+                function __mm__realloc($void, $size) {
+                    $result = _erealloc($void, $size, $jit, $two, $jit, $two);
+                    return $result;
+                }
+            }
+            compile {
+                function __mm__free($void) {
+                    _efree($void, $jit, $two, $jit, $two);
+                    return;
+                }
+            }
+        } else {
+            compile {
+                function __mm__malloc($size) {
+                    $result = _emalloc($size);
+                    return $result;
+                }
+            }
+            compile {
+                function __mm__realloc($void, $size) {
+                    $result = _erealloc($void, $size);
+                    return $result;
+                }
+            }
+            compile {
+                function __mm__free($void) {
+                    _efree($void);
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/lib/JIT/Builtin/MemoryManager/PHP.pre
+++ b/lib/JIT/Builtin/MemoryManager/PHP.pre
@@ -36,7 +36,9 @@ class PHP extends MemoryManager {
             // These variables are a hack because compile{}
             // blocks currently only accept variables as arguments.
             $jit = $this->context->constantFromString("jit");
-            $two = 2;
+            compile {
+                $two = (int32) 2;
+            }
 
             compile {
                 function __mm__malloc($size) {

--- a/lib/JIT/Builtin/Output.php
+++ b/lib/JIT/Builtin/Output.php
@@ -1,15 +1,7 @@
 <?php
 
-declare(strict_types=1);
-
-/**
- * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
- *
- * @copyright 2015 Anthony Ferrara. All rights reserved
- * @license MIT See LICENSE at the root of the project for more info
- */
-
-// Change /compiler/lib/JIT/Builtin/Output.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT/Builtin/Output.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
@@ -17,60 +9,75 @@ declare(strict_types=1);
  * @copyright 2015 Anthony Ferrara. All rights reserved
  * @license MIT See LICENSE at the root of the project for more info
  */
+
 namespace PHPCompiler\JIT\Builtin;
 
 use PHPCompiler\JIT\Builtin;
 
-class Output extends Builtin
-{
-    public function register(): void
-    {
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
-            $this->context->getTypeFromString('int32'),
-            true,
-            $this->context->getTypeFromString('char*')
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
-            'printf',
-            $fntype___cfcd208495d565ef66e7dff9f98764da
-        );
+class Output extends Builtin {
 
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(0 + 1, $this->context->attributes['readonly'], 0);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(0 + 1, $this->context->attributes['nocapture'], 0);
-
-        $this->context->registerFunction('printf', $fn___cfcd208495d565ef66e7dff9f98764da);
+    public function register(): void {
+        
 
         $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
-            $this->context->getTypeFromString('int32'),
-            true,
-            $this->context->getTypeFromString('char*'),
-            $this->context->getTypeFromString('char*')
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
-            'sprintf',
-            $fntype___cfcd208495d565ef66e7dff9f98764da
-        );
+                $this->context->getTypeFromString('int32'),
+                true ,  
+                $this->context->getTypeFromString('char*')
+                 
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('printf', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(0 + 1, $this->context->attributes['readonly'], 0);
+                    $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(0 + 1, $this->context->attributes['nocapture'], 0);
+                
+             
+            $this->context->registerFunction('printf', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(1 + 1, $this->context->attributes['readonly'], 0);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(1 + 1, $this->context->attributes['nocapture'], 0);
-
-        $this->context->registerFunction('sprintf', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
+    
 
         $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
-            $this->context->getTypeFromString('int32'),
-            true,
-            $this->context->getTypeFromString('char*'),
-            $this->context->getTypeFromString('size_t'),
-            $this->context->getTypeFromString('char*')
-        );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction(
-            'snprintf',
-            $fntype___cfcd208495d565ef66e7dff9f98764da
-        );
+                $this->context->getTypeFromString('int32'),
+                true ,  
+                $this->context->getTypeFromString('char*')
+                , $this->context->getTypeFromString('char*')
+                 
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('sprintf', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            
+            
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(1 + 1, $this->context->attributes['readonly'], 0);
+                    $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(1 + 1, $this->context->attributes['nocapture'], 0);
+                
+             
+            $this->context->registerFunction('sprintf', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(2 + 1, $this->context->attributes['readonly'], 0);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(2 + 1, $this->context->attributes['nocapture'], 0);
+        
+    
 
-        $this->context->registerFunction('snprintf', $fn___cfcd208495d565ef66e7dff9f98764da);
+        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+                $this->context->getTypeFromString('int32'),
+                true ,  
+                $this->context->getTypeFromString('char*')
+                , $this->context->getTypeFromString('size_t')
+                , $this->context->getTypeFromString('char*')
+                 
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('snprintf', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            
+            
+            
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(2 + 1, $this->context->attributes['readonly'], 0);
+                    $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(2 + 1, $this->context->attributes['nocapture'], 0);
+                
+             
+            $this->context->registerFunction('snprintf', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
+
+        
+    
     }
+
 }

--- a/lib/JIT/Builtin/Refcount.php
+++ b/lib/JIT/Builtin/Refcount.php
@@ -1,7 +1,7 @@
 <?php
 
-// This file is generated and changes you make will be lost.
-// Change /compiler/lib/JIT/Builtin/Refcount.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT/Builtin/Refcount.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code

--- a/lib/JIT/Builtin/Type/String_.php
+++ b/lib/JIT/Builtin/Type/String_.php
@@ -1,7 +1,7 @@
 <?php
 
-// This file is generated and changes you make will be lost.
-// Change /compiler/lib/JIT/Builtin/Type/String_.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT/Builtin/Type/String_.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code

--- a/lib/JIT/Builtin/Type/Value.php
+++ b/lib/JIT/Builtin/Type/Value.php
@@ -1,15 +1,7 @@
 <?php
 
-declare(strict_types=1);
-
-/**
- * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
- *
- * @copyright 2015 Anthony Ferrara. All rights reserved
- * @license MIT See LICENSE at the root of the project for more info
- */
-
-// Change /compiler/lib/JIT/Builtin/Type/Value.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT/Builtin/Type/Value.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code
@@ -17,147 +9,220 @@ declare(strict_types=1);
  * @copyright 2015 Anthony Ferrara. All rights reserved
  * @license MIT See LICENSE at the root of the project for more info
  */
+
 namespace PHPCompiler\JIT\Builtin\Type;
 
 use PHPCompiler\JIT\Builtin\Type;
 use PHPCompiler\JIT\Variable;
 
-class Value extends Type
-{
-    public function register(): void
-    {
+class Value extends Type {
+
+    public function register(): void {
+        
+
+        
+
         $struct___cfcd208495d565ef66e7dff9f98764da = $this->context->context->namedStructType('__value__');
-        // declare first so recursive structs are possible :)
-        $this->context->registerType('__value__', $struct___cfcd208495d565ef66e7dff9f98764da);
-        $this->context->registerType('__value__'.'*', $struct___cfcd208495d565ef66e7dff9f98764da->pointerType(0));
-        $this->context->registerType('__value__'.'**', $struct___cfcd208495d565ef66e7dff9f98764da->pointerType(0)->pointerType(0));
-        $struct___cfcd208495d565ef66e7dff9f98764da->setBody(
-                false,  // packed
-                $this->context->getTypeFromString('int8'), $this->context->getTypeFromString('int8[8]')
-
+            // declare first so recursive structs are possible :)
+            $this->context->registerType('__value__', $struct___cfcd208495d565ef66e7dff9f98764da);
+            $this->context->registerType('__value__' . '*', $struct___cfcd208495d565ef66e7dff9f98764da->pointerType(0));
+            $this->context->registerType('__value__' . '**', $struct___cfcd208495d565ef66e7dff9f98764da->pointerType(0)->pointerType(0));
+            $struct___cfcd208495d565ef66e7dff9f98764da->setBody(
+                false ,  // packed
+                $this->context->getTypeFromString('int8')
+                , $this->context->getTypeFromString('int8[8]')
+                
             );
-        $this->context->structFieldMap['__value__'] = [
-            'type' => 0, 'value' => 1,
+            $this->context->structFieldMap['__value__'] = [
+                'type' => 0
+                , 'value' => 1
+                
+            ];
+        
+    
 
-        ];
+        
 
         $struct___cfcd208495d565ef66e7dff9f98764da = $this->context->context->namedStructType('__value__value');
-        // declare first so recursive structs are possible :)
-        $this->context->registerType('__value__value', $struct___cfcd208495d565ef66e7dff9f98764da);
-        $this->context->registerType('__value__value'.'*', $struct___cfcd208495d565ef66e7dff9f98764da->pointerType(0));
-        $this->context->registerType('__value__value'.'**', $struct___cfcd208495d565ef66e7dff9f98764da->pointerType(0)->pointerType(0));
-        $struct___cfcd208495d565ef66e7dff9f98764da->setBody(
-                false,  // packed
-                $this->context->getTypeFromString('__ref__'), $this->context->getTypeFromString('__value__')
-
+            // declare first so recursive structs are possible :)
+            $this->context->registerType('__value__value', $struct___cfcd208495d565ef66e7dff9f98764da);
+            $this->context->registerType('__value__value' . '*', $struct___cfcd208495d565ef66e7dff9f98764da->pointerType(0));
+            $this->context->registerType('__value__value' . '**', $struct___cfcd208495d565ef66e7dff9f98764da->pointerType(0)->pointerType(0));
+            $struct___cfcd208495d565ef66e7dff9f98764da->setBody(
+                false ,  // packed
+                $this->context->getTypeFromString('__ref__')
+                , $this->context->getTypeFromString('__value__')
+                
             );
-        $this->context->structFieldMap['__value__value'] = [
-            'ref' => 0, 'value' => 1,
-
-        ];
-
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+            $this->context->structFieldMap['__value__value'] = [
+                'ref' => 0
+                , 'value' => 1
+                
+            ];
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
                 $this->context->getTypeFromString('void'),
-                false,
+                false , 
                 $this->context->getTypeFromString('__value__*')
-
+                
             );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__valueDelref', $fntype___cfcd208495d565ef66e7dff9f98764da);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__valueDelref', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            $this->context->registerFunction('__value__valueDelref', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('__value__valueDelref', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
                 $this->context->getTypeFromString('__value__*'),
-                false,
+                false , 
                 $this->context->getTypeFromString('__value__*')
-
+                
             );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__toNumeric', $fntype___cfcd208495d565ef66e7dff9f98764da);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__toNumeric', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            $this->context->registerFunction('__value__toNumeric', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('__value__toNumeric', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
                 $this->context->getTypeFromString('int64'),
-                false,
+                false , 
                 $this->context->getTypeFromString('__value__*')
-
+                
             );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__readLong', $fntype___cfcd208495d565ef66e7dff9f98764da);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__readLong', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            $this->context->registerFunction('__value__readLong', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('__value__readLong', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
                 $this->context->getTypeFromString('void'),
-                false,
-                $this->context->getTypeFromString('__value__*'), $this->context->getTypeFromString('int64')
-
+                false , 
+                $this->context->getTypeFromString('__value__*')
+                , $this->context->getTypeFromString('int64')
+                
             );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__writeLong', $fntype___cfcd208495d565ef66e7dff9f98764da);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__writeLong', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            
+            $this->context->registerFunction('__value__writeLong', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('__value__writeLong', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
                 $this->context->getTypeFromString('double'),
-                false,
+                false , 
                 $this->context->getTypeFromString('__value__*')
-
+                
             );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__readDouble', $fntype___cfcd208495d565ef66e7dff9f98764da);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__readDouble', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            $this->context->registerFunction('__value__readDouble', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('__value__readDouble', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
                 $this->context->getTypeFromString('void'),
-                false,
-                $this->context->getTypeFromString('__value__*'), $this->context->getTypeFromString('double')
-
+                false , 
+                $this->context->getTypeFromString('__value__*')
+                , $this->context->getTypeFromString('double')
+                
             );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__writeDouble', $fntype___cfcd208495d565ef66e7dff9f98764da);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__writeDouble', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            
+            $this->context->registerFunction('__value__writeDouble', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('__value__writeDouble', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
                 $this->context->getTypeFromString('__string__*'),
-                false,
+                false , 
                 $this->context->getTypeFromString('__value__*')
-
+                
             );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__readString', $fntype___cfcd208495d565ef66e7dff9f98764da);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__readString', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            $this->context->registerFunction('__value__readString', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('__value__readString', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
                 $this->context->getTypeFromString('void'),
-                false,
-                $this->context->getTypeFromString('__value__*'), $this->context->getTypeFromString('__string__*')
-
-            );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__writeString', $fntype___cfcd208495d565ef66e7dff9f98764da);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
-
-        $this->context->registerFunction('__value__writeString', $fn___cfcd208495d565ef66e7dff9f98764da);
-
-        $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
-                $this->context->getTypeFromString('void'),
-                false,
+                false , 
                 $this->context->getTypeFromString('__value__*')
-
+                , $this->context->getTypeFromString('__string__*')
+                
             );
-        $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__writeNull', $fntype___cfcd208495d565ef66e7dff9f98764da);
-        $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__writeString', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            
+            $this->context->registerFunction('__value__writeString', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
 
-        $this->context->registerFunction('__value__writeNull', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
+
+        
+    $fntype___cfcd208495d565ef66e7dff9f98764da = $this->context->context->functionType(
+                $this->context->getTypeFromString('void'),
+                false , 
+                $this->context->getTypeFromString('__value__*')
+                
+            );
+            $fn___cfcd208495d565ef66e7dff9f98764da = $this->context->module->addFunction('__value__writeNull', $fntype___cfcd208495d565ef66e7dff9f98764da);
+            $fn___cfcd208495d565ef66e7dff9f98764da->addAttributeAtIndex(\PHPLLVM\Attribute::INDEX_FUNCTION, $this->context->attributes['alwaysinline']);
+            
+            
+            
+            $this->context->registerFunction('__value__writeNull', $fn___cfcd208495d565ef66e7dff9f98764da);
+        
+
+        
+
+        
+    
     }
 
-    public function implement(): void
-    {
+    public function implement(): void {
         $this->implementValueToNumeric();
         $this->implementValueReadLong();
         $this->implementValueWriteLong();
@@ -167,846 +232,28 @@ class Value extends Type
         $this->implementValueDelref();
     }
 
-    public function initialize(): void
-    {
+    public function initialize(): void {
     }
 
-    public function implementValueWriteLong(): void
-    {
-        $fn___9bf31c7ff062936a96d3c8bd1f8f2ff3 = $this->context->lookupFunction('__value__writeLong');
-        $block___9bf31c7ff062936a96d3c8bd1f8f2ff3 = $fn___9bf31c7ff062936a96d3c8bd1f8f2ff3->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___9bf31c7ff062936a96d3c8bd1f8f2ff3);
-        $value = $fn___9bf31c7ff062936a96d3c8bd1f8f2ff3->getParam(0);
-        $long = $fn___9bf31c7ff062936a96d3c8bd1f8f2ff3->getParam(1);
-
-        $this->context->builder->call(
-                    $this->context->lookupFunction('__value__valueDelref'),
-                    $value
-
-                );
-        $__type = $this->context->getTypeFromString('int8');
-
-        $__kind = $__type->getKind();
-        $__value = Variable::TYPE_NATIVE_LONG;
-        switch ($__kind) {
-                        case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
-                                $type = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
-                                        $type = $this->context->builder->truncOrBitCast($__value, $__type);
-                                    } else {
-                                        $type = $this->context->builder->zExtOrBitCast($__value, $__type);
-                                    }
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-
-                                    $type = $this->context->builder->fpToSi($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $type = $this->context->builder->ptrToInt($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
-                                $type = $__type->constReal(Variable::TYPE_NATIVE_LONG);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-
-                                    $type = $this->context->builder->siToFp($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-                                    $type = $this->context->builder->fpCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_ARRAY:
-                        case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
-                                // this is very likely very wrong...
-                                $type = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    $type = $this->context->builder->intToPtr($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
-                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
-                                    // break;
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $type = $this->context->builder->pointerCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
-                    }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
-        $this->context->builder->store(
-                    $type,
-                    $this->context->builder->structGep($value, $offset)
-                );
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $ptr = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('int64*');
-
-        $__kind = $__type->getKind();
-        $__value = $ptr;
-        switch ($__kind) {
-                        case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
-                                $resultPtr = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
-                                        $resultPtr = $this->context->builder->truncOrBitCast($__value, $__type);
-                                    } else {
-                                        $resultPtr = $this->context->builder->zExtOrBitCast($__value, $__type);
-                                    }
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-
-                                    $resultPtr = $this->context->builder->fpToSi($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $resultPtr = $this->context->builder->ptrToInt($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
-                                $resultPtr = $__type->constReal($ptr);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-
-                                    $resultPtr = $this->context->builder->siToFp($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-                                    $resultPtr = $this->context->builder->fpCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_ARRAY:
-                        case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
-                                // this is very likely very wrong...
-                                $resultPtr = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    $resultPtr = $this->context->builder->intToPtr($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
-                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
-                                    // break;
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $resultPtr = $this->context->builder->pointerCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
-                    }
-        $__type = $this->context->getTypeFromString('int32');
-
-        $__kind = $__type->getKind();
-        $__value = 0;
-        switch ($__kind) {
-                        case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
-                                $offset = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
-                                        $offset = $this->context->builder->truncOrBitCast($__value, $__type);
-                                    } else {
-                                        $offset = $this->context->builder->zExtOrBitCast($__value, $__type);
-                                    }
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-
-                                    $offset = $this->context->builder->fpToSi($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $offset = $this->context->builder->ptrToInt($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
-                                $offset = $__type->constReal(0);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-
-                                    $offset = $this->context->builder->siToFp($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-                                    $offset = $this->context->builder->fpCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_ARRAY:
-                        case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
-                                // this is very likely very wrong...
-                                $offset = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    $offset = $this->context->builder->intToPtr($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
-                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
-                                    // break;
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $offset = $this->context->builder->pointerCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
-                    }
-        $this->context->builder->store($long, $this->context->builder->gep(
-                    $resultPtr,
-                    //$this->context->context->int32Type()->constInt(0, false),
-                    //$this->context->context->int32Type()->constInt(0, false),
-                    $offset
-                ));
-        $this->context->builder->returnVoid();
-
-        $this->context->builder->clearInsertionPosition();
-    }
-
-    public function implementValueWriteDouble(): void
-    {
-        $fn___b6d767d2f8ed5d21a44b0e5886680cb9 = $this->context->lookupFunction('__value__writeDouble');
-        $block___b6d767d2f8ed5d21a44b0e5886680cb9 = $fn___b6d767d2f8ed5d21a44b0e5886680cb9->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___b6d767d2f8ed5d21a44b0e5886680cb9);
-        $value = $fn___b6d767d2f8ed5d21a44b0e5886680cb9->getParam(0);
-        $double = $fn___b6d767d2f8ed5d21a44b0e5886680cb9->getParam(1);
-
-        $this->context->builder->call(
-                    $this->context->lookupFunction('__value__valueDelref'),
-                    $value
-
-                );
-        $__type = $this->context->getTypeFromString('int8');
-
-        $__kind = $__type->getKind();
-        $__value = Variable::TYPE_NATIVE_DOUBLE;
-        switch ($__kind) {
-                        case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
-                                $type = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
-                                        $type = $this->context->builder->truncOrBitCast($__value, $__type);
-                                    } else {
-                                        $type = $this->context->builder->zExtOrBitCast($__value, $__type);
-                                    }
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-
-                                    $type = $this->context->builder->fpToSi($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $type = $this->context->builder->ptrToInt($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
-                                $type = $__type->constReal(Variable::TYPE_NATIVE_DOUBLE);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-
-                                    $type = $this->context->builder->siToFp($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-                                    $type = $this->context->builder->fpCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_ARRAY:
-                        case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
-                                // this is very likely very wrong...
-                                $type = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    $type = $this->context->builder->intToPtr($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
-                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
-                                    // break;
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $type = $this->context->builder->pointerCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
-                    }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
-        $this->context->builder->store(
-                    $type,
-                    $this->context->builder->structGep($value, $offset)
-                );
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $ptr = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('double*');
-
-        $__kind = $__type->getKind();
-        $__value = $ptr;
-        switch ($__kind) {
-                        case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
-                                $resultPtr = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
-                                        $resultPtr = $this->context->builder->truncOrBitCast($__value, $__type);
-                                    } else {
-                                        $resultPtr = $this->context->builder->zExtOrBitCast($__value, $__type);
-                                    }
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-
-                                    $resultPtr = $this->context->builder->fpToSi($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $resultPtr = $this->context->builder->ptrToInt($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
-                                $resultPtr = $__type->constReal($ptr);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-
-                                    $resultPtr = $this->context->builder->siToFp($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-                                    $resultPtr = $this->context->builder->fpCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_ARRAY:
-                        case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
-                                // this is very likely very wrong...
-                                $resultPtr = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    $resultPtr = $this->context->builder->intToPtr($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
-                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
-                                    // break;
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $resultPtr = $this->context->builder->pointerCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
-                    }
-        $__type = $this->context->getTypeFromString('int32');
-
-        $__kind = $__type->getKind();
-        $__value = 0;
-        switch ($__kind) {
-                        case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
-                                $offset = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
-                                        $offset = $this->context->builder->truncOrBitCast($__value, $__type);
-                                    } else {
-                                        $offset = $this->context->builder->zExtOrBitCast($__value, $__type);
-                                    }
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-
-                                    $offset = $this->context->builder->fpToSi($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $offset = $this->context->builder->ptrToInt($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
-                                $offset = $__type->constReal(0);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-
-                                    $offset = $this->context->builder->siToFp($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-                                    $offset = $this->context->builder->fpCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_ARRAY:
-                        case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
-                                // this is very likely very wrong...
-                                $offset = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    $offset = $this->context->builder->intToPtr($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
-                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
-                                    // break;
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $offset = $this->context->builder->pointerCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
-                    }
-        $this->context->builder->store($double, $this->context->builder->gep(
-                    $resultPtr,
-                    //$this->context->context->int32Type()->constInt(0, false),
-                    //$this->context->context->int32Type()->constInt(0, false),
-                    $offset
-                ));
-        $this->context->builder->returnVoid();
-
-        $this->context->builder->clearInsertionPosition();
-    }
-
-    public function implementValueWriteString(): void
-    {
-        $fn___33e75ff09dd601bbe69f351039152189 = $this->context->lookupFunction('__value__writeString');
-        $block___33e75ff09dd601bbe69f351039152189 = $fn___33e75ff09dd601bbe69f351039152189->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___33e75ff09dd601bbe69f351039152189);
-        $value = $fn___33e75ff09dd601bbe69f351039152189->getParam(0);
-        $string = $fn___33e75ff09dd601bbe69f351039152189->getParam(1);
-
-        $this->context->builder->call(
-                    $this->context->lookupFunction('__value__valueDelref'),
-                    $value
-
-                );
-        $__type = $this->context->getTypeFromString('int8');
-
-        $__kind = $__type->getKind();
-        $__value = Variable::TYPE_STRING;
-        switch ($__kind) {
-                        case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
-                                $type = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
-                                        $type = $this->context->builder->truncOrBitCast($__value, $__type);
-                                    } else {
-                                        $type = $this->context->builder->zExtOrBitCast($__value, $__type);
-                                    }
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-
-                                    $type = $this->context->builder->fpToSi($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $type = $this->context->builder->ptrToInt($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
-                                $type = $__type->constReal(Variable::TYPE_STRING);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-
-                                    $type = $this->context->builder->siToFp($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-                                    $type = $this->context->builder->fpCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_ARRAY:
-                        case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
-                                // this is very likely very wrong...
-                                $type = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    $type = $this->context->builder->intToPtr($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
-                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
-                                    // break;
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $type = $this->context->builder->pointerCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
-                    }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
-        $this->context->builder->store(
-                    $type,
-                    $this->context->builder->structGep($value, $offset)
-                );
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $this->context->builder->store(
-                    $string,
-                    $this->context->builder->structGep($value, $offset)
-                );
-        $this->context->builder->returnVoid();
-
-        $this->context->builder->clearInsertionPosition();
-    }
-
-    public function implementValueWriteNull(): void
-    {
-        $fn___34173cb38f07f89ddbebc2ac9128303f = $this->context->lookupFunction('__value__writeNull');
-        $block___34173cb38f07f89ddbebc2ac9128303f = $fn___34173cb38f07f89ddbebc2ac9128303f->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___34173cb38f07f89ddbebc2ac9128303f);
-        $value = $fn___34173cb38f07f89ddbebc2ac9128303f->getParam(0);
-
-        $this->context->builder->call(
-                    $this->context->lookupFunction('__value__valueDelref'),
-                    $value
-
-                );
-        $__type = $this->context->getTypeFromString('int8');
-
-        $__kind = $__type->getKind();
-        $__value = Variable::TYPE_NULL;
-        switch ($__kind) {
-                        case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
-                                $type = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
-                                        $type = $this->context->builder->truncOrBitCast($__value, $__type);
-                                    } else {
-                                        $type = $this->context->builder->zExtOrBitCast($__value, $__type);
-                                    }
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-
-                                    $type = $this->context->builder->fpToSi($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $type = $this->context->builder->ptrToInt($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
-                                $type = $__type->constReal(Variable::TYPE_NULL);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-
-                                    $type = $this->context->builder->siToFp($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_DOUBLE:
-                                    $type = $this->context->builder->fpCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        case \PHPLLVM\Type::KIND_ARRAY:
-                        case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
-                                // this is very likely very wrong...
-                                $type = $__type->constInt($__value, false);
-
-                                break;
-                            }
-                            $__other_type = $__value->typeOf();
-                            switch ($__other_type->getKind()) {
-                                case \PHPLLVM\Type::KIND_INTEGER:
-                                    $type = $this->context->builder->intToPtr($__value, $__type);
-
-                                    break;
-                                case \PHPLLVM\Type::KIND_ARRAY:
-                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
-                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
-                                    // break;
-                                case \PHPLLVM\Type::KIND_POINTER:
-                                    $type = $this->context->builder->pointerCast($__value, $__type);
-
-                                    break;
-                                default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
-                            }
-
-                            break;
-                        default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
-                    }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
-        $this->context->builder->store(
-                    $type,
-                    $this->context->builder->structGep($value, $offset)
-                );
-        $this->context->builder->returnVoid();
-
-        $this->context->builder->clearInsertionPosition();
-    }
-
-    protected function implementValueDelref(): void
-    {
+    protected function implementValueDelref(): void {
         $fn___c4ca4238a0b923820dcc509a6f75849b = $this->context->lookupFunction('__value__valueDelref');
-        $block___c4ca4238a0b923820dcc509a6f75849b = $fn___c4ca4238a0b923820dcc509a6f75849b->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___c4ca4238a0b923820dcc509a6f75849b);
-        $value = $fn___c4ca4238a0b923820dcc509a6f75849b->getParam(0);
-
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
-        $oldType = $this->context->builder->load(
+    $block___c4ca4238a0b923820dcc509a6f75849b = $fn___c4ca4238a0b923820dcc509a6f75849b->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___c4ca4238a0b923820dcc509a6f75849b);
+    $value = $fn___c4ca4238a0b923820dcc509a6f75849b->getParam(0);
+    
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
+                    $oldType = $this->context->builder->load(
                         $this->context->builder->structGep($value, $offset)
                     );
-        $__type = $this->context->getTypeFromString('int8');
-
-        $__kind = $__type->getKind();
-        $__value = Variable::IS_REFCOUNTED;
-        switch ($__kind) {
+    $__type = $this->context->getTypeFromString('int8');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = Variable::IS_REFCOUNTED;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $mask = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -1017,58 +264,50 @@ class Value extends Type
                                     } else {
                                         $mask = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $mask = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $mask = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $mask = $__type->constReal(Variable::IS_REFCOUNTED);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $mask = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $mask = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $mask = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $mask = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -1076,39 +315,40 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $mask = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $__right = $this->context->builder->intCast($mask, $oldType->typeOf());
+    $__right = $this->context->builder->intCast($mask, $oldType->typeOf());
+                            
+                            
+                        
 
-        $isCounted = $this->context->builder->bitwiseAnd($oldType, $__right);
-        $bool = $this->context->castToBool($isCounted);
-        $prev = $this->context->builder->getInsertBlock();
-        $ifBlock = $prev->insertBasicBlock('ifBlock');
-        $prev->moveBefore($ifBlock);
-
-        $endBlock[] = $tmp = $ifBlock->insertBasicBlock('endBlock');
-        $this->context->builder->branchIf($bool, $ifBlock, $tmp);
-
-        $this->context->builder->positionAtEnd($ifBlock);
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $ptr = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('__ref__virtual*');
-
-        $__kind = $__type->getKind();
-        $__value = $ptr;
-        switch ($__kind) {
+                        $isCounted = $this->context->builder->bitwiseAnd($oldType, $__right);
+    $bool = $this->context->castToBool($isCounted);
+                $prev = $this->context->builder->getInsertBlock();
+                $ifBlock = $prev->insertBasicBlock('ifBlock');
+                $prev->moveBefore($ifBlock);
+                
+                $endBlock[] = $tmp = $ifBlock->insertBasicBlock('endBlock');
+                    $this->context->builder->branchIf($bool, $ifBlock, $tmp);
+                
+                $this->context->builder->positionAtEnd($ifBlock);
+                { $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $ptr = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('__ref__virtual*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $ptr;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $virtual = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -1119,58 +359,50 @@ class Value extends Type
                                     } else {
                                         $virtual = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $virtual = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $virtual = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $virtual = $__type->constReal($ptr);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $virtual = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $virtual = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $virtual = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $virtual = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -1178,74 +410,71 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $virtual = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->call(
-                    $this->context->lookupFunction('__ref__delref'),
+    $this->context->builder->call(
+                    $this->context->lookupFunction('__ref__delref') , 
                     $virtual
-
+                    
                 );
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($endBlock));
-        }
-
-        $this->context->builder->positionAtEnd(array_pop($endBlock));
-        $this->context->builder->returnVoid();
-
-        $this->context->builder->clearInsertionPosition();
+    }
+                if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                    $this->context->builder->branch(end($endBlock));
+                }
+                
+                $this->context->builder->positionAtEnd(array_pop($endBlock));
+    $this->context->builder->returnVoid();
+    
+    $this->context->builder->clearInsertionPosition();
     }
 
-    protected function implementValueToNumeric(): void
-    {
+    protected function implementValueToNumeric(): void {
         $fn___a87ff679a2f3e71d9181a67b7542122c = $this->context->lookupFunction('__value__toNumeric');
-        $block___a87ff679a2f3e71d9181a67b7542122c = $fn___a87ff679a2f3e71d9181a67b7542122c->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___a87ff679a2f3e71d9181a67b7542122c);
-        $value = $fn___a87ff679a2f3e71d9181a67b7542122c->getParam(0);
-
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
-        $type = $this->context->builder->load(
+    $block___a87ff679a2f3e71d9181a67b7542122c = $fn___a87ff679a2f3e71d9181a67b7542122c->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___a87ff679a2f3e71d9181a67b7542122c);
+    $value = $fn___a87ff679a2f3e71d9181a67b7542122c->getParam(0);
+    
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
+                    $type = $this->context->builder->load(
                         $this->context->builder->structGep($value, $offset)
                     );
-        $__switches[] = $__switch = new \StdClass();
-        $__switch->type = $type->typeOf();
-        $__prev = $this->context->builder->getInsertBlock();
-        $__switch->default = $__prev->insertBasicBlock('default');
-        $__prev->moveBefore($__switch->default);
-        $__switch->end = $__switch->default->insertBasicBlock('end');
-        $__switch->endIsUsed = false;
-        $__switch->numCases = 0;
-        ++$__switch->numCases;
-        ++$__switch->numCases;
-        ++$__switch->numCases;
-
-        $__switch->switch = $this->context->builder->branchSwitch($type, $__switch->default, $__switch->numCases);
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_NATIVE_LONG)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_LONG, false), $__case);
-        } elseif (Variable::TYPE_NATIVE_LONG instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_NATIVE_LONG, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $__type = $this->context->getTypeFromString('__ref__virtual*');
-
-        $__kind = $__type->getKind();
-        $__value = $value;
-        switch ($__kind) {
+    $__switches[] = $__switch = new \StdClass;
+                $__switch->type = $type->typeOf();
+                $__prev = $this->context->builder->getInsertBlock();
+                $__switch->default = $__prev->insertBasicBlock('default');
+                $__prev->moveBefore($__switch->default);
+                $__switch->end = $__switch->default->insertBasicBlock('end');
+                $__switch->endIsUsed = false;
+                $__switch->numCases = 0;
+                $__switch->numCases++;
+                $__switch->numCases++;
+                $__switch->numCases++;
+                
+                $__switch->switch = $this->context->builder->branchSwitch($type, $__switch->default, $__switch->numCases);
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_NATIVE_LONG)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_LONG, false), $__case);
+                    } elseif (Variable::TYPE_NATIVE_LONG instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_NATIVE_LONG, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $__type = $this->context->getTypeFromString('__ref__virtual*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $value;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $var = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -1256,58 +485,50 @@ class Value extends Type
                                     } else {
                                         $var = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $var = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $var = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $var = $__type->constReal($value);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $var = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $var = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $var = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $var = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -1315,45 +536,43 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $var = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->call(
-                    $this->context->lookupFunction('__ref__addref'),
+    $this->context->builder->call(
+                    $this->context->lookupFunction('__ref__addref') , 
                     $var
-
+                    
                 );
-        $this->context->builder->returnValue($value);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_NATIVE_DOUBLE)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_DOUBLE, false), $__case);
-        } elseif (Variable::TYPE_NATIVE_DOUBLE instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_NATIVE_DOUBLE, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $__type = $this->context->getTypeFromString('__ref__virtual*');
-
-        $__kind = $__type->getKind();
-        $__value = $value;
-        switch ($__kind) {
+    $this->context->builder->returnValue($value);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_NATIVE_DOUBLE)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_DOUBLE, false), $__case);
+                    } elseif (Variable::TYPE_NATIVE_DOUBLE instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_NATIVE_DOUBLE, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $__type = $this->context->getTypeFromString('__ref__virtual*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $value;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $var = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -1364,58 +583,50 @@ class Value extends Type
                                     } else {
                                         $var = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $var = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $var = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $var = $__type->constReal($value);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $var = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $var = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $var = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $var = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -1423,47 +634,45 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $var = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->call(
-                    $this->context->lookupFunction('__ref__addref'),
+    $this->context->builder->call(
+                    $this->context->lookupFunction('__ref__addref') , 
                     $var
-
+                    
                 );
-        $this->context->builder->returnValue($value);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_VALUE)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_VALUE, false), $__case);
-        } elseif (Variable::TYPE_VALUE instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_VALUE, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $var = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('__value__value*');
-
-        $__kind = $__type->getKind();
-        $__value = $var;
-        switch ($__kind) {
+    $this->context->builder->returnValue($value);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_VALUE)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_VALUE, false), $__case);
+                    } elseif (Variable::TYPE_VALUE instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_VALUE, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $var = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('__value__value*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $var;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $ptr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -1474,58 +683,50 @@ class Value extends Type
                                     } else {
                                         $ptr = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $ptr = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $ptr = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $ptr = $__type->constReal($var);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $ptr = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $ptr = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $ptr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $ptr = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -1533,44 +734,69 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $ptr = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $offset = $this->context->structFieldMap[$ptr->typeOf()->getElementType()->getName()]['value'];
-        $num = $this->context->builder->structGep($ptr, $offset);
-        $result = $this->context->builder->call(
-                        $this->context->lookupFunction('__value__toNumeric'),
+    $offset = $this->context->structFieldMap[$ptr->typeOf()->getElementType()->getName()]['value'];
+                    $num = $this->context->builder->structGep($ptr, $offset);
+    $result = $this->context->builder->call(
+                        $this->context->lookupFunction('__value__toNumeric') , 
                         $num
-
+                        
                     );
-        $__right = $this->context->builder->intCast($num, $result->typeOf());
+    $__right = $this->context->builder->intCast($num, $result->typeOf());
+                            
+                            
+                        
 
-        $test = $this->context->builder->icmp(\PHPLLVM\Builder::INT_EQ, $result, $__right);
-        $bool = $this->context->castToBool($test);
-        $prev = $this->context->builder->getInsertBlock();
-        $ifBlock = $prev->insertBasicBlock('ifBlock');
-        $prev->moveBefore($ifBlock);
+                        
 
-        $endBlock[] = $tmp = $ifBlock->insertBasicBlock('endBlock');
-        $this->context->builder->branchIf($bool, $ifBlock, $tmp);
+                        
 
-        $this->context->builder->positionAtEnd($ifBlock);
-        $__type = $this->context->getTypeFromString('__ref__virtual*');
+                        
 
-        $__kind = $__type->getKind();
-        $__value = $var;
-        switch ($__kind) {
+                        
+
+                        
+
+                        
+
+                        
+
+                        
+
+                        
+
+                        
+
+                        
+
+                        
+
+                        $test = $this->context->builder->icmp(\PHPLLVM\Builder::INT_EQ, $result, $__right);
+    $bool = $this->context->castToBool($test);
+                $prev = $this->context->builder->getInsertBlock();
+                $ifBlock = $prev->insertBasicBlock('ifBlock');
+                $prev->moveBefore($ifBlock);
+                
+                $endBlock[] = $tmp = $ifBlock->insertBasicBlock('endBlock');
+                    $this->context->builder->branchIf($bool, $ifBlock, $tmp);
+                
+                $this->context->builder->positionAtEnd($ifBlock);
+                { $__type = $this->context->getTypeFromString('__ref__virtual*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $var;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $virtual = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -1581,58 +807,50 @@ class Value extends Type
                                     } else {
                                         $virtual = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $virtual = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $virtual = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $virtual = $__type->constReal($var);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $virtual = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $virtual = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $virtual = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $virtual = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -1640,57 +858,55 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $virtual = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->call(
-                    $this->context->lookupFunction('__ref__addref'),
+    $this->context->builder->call(
+                    $this->context->lookupFunction('__ref__addref') , 
                     $virtual
-
+                    
                 );
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($endBlock));
-        }
-
-        $this->context->builder->positionAtEnd(array_pop($endBlock));
-        $this->context->builder->returnValue($result);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-
-        $this->context->builder->positionAtEnd(end($__switches)->default);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__switch = array_pop($__switches);
-        if ($__switch->endIsUsed) {
-            $this->context->builder->positionAtEnd($__switch->end);
-        } else {
-            $__switch->end->remove();
-        }
-        $type = $this->context->getTypeFromString('__value__');
-        $var = $this->context->builder->alloca($type);
-        $__type = $this->context->getTypeFromString('int64');
-
-        $__kind = $__type->getKind();
-        $__value = 0;
-        switch ($__kind) {
+    }
+                if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                    $this->context->builder->branch(end($endBlock));
+                }
+                
+                $this->context->builder->positionAtEnd(array_pop($endBlock));
+    $this->context->builder->returnValue($result);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                
+                $this->context->builder->positionAtEnd(end($__switches)->default);
+                
+                if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                    $this->context->builder->branch(end($__switches)->end);
+                    end($__switches)->endIsUsed = true;
+                }
+                $__switch = array_pop($__switches);
+                if ($__switch->endIsUsed) {
+                    $this->context->builder->positionAtEnd($__switch->end);
+                } else {
+                    $__switch->end->remove();
+                }
+    $type = $this->context->getTypeFromString('__value__');
+                    $var = $this->context->builder->alloca($type);
+    $__type = $this->context->getTypeFromString('int64');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = 0;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $tmp = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -1701,58 +917,50 @@ class Value extends Type
                                     } else {
                                         $tmp = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $tmp = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $tmp = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $tmp = $__type->constReal(0);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $tmp = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $tmp = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $tmp = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $tmp = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -1760,70 +968,68 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $tmp = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->call(
-                    $this->context->lookupFunction('__value__writeLong'),
-                    $var, $tmp
-
+    $this->context->builder->call(
+                    $this->context->lookupFunction('__value__writeLong') , 
+                    $var
+                    , $tmp
+                    
                 );
-        $this->context->builder->returnValue($var);
-
-        $this->context->builder->clearInsertionPosition();
+    $this->context->builder->returnValue($var);
+    
+    $this->context->builder->clearInsertionPosition();
     }
 
-    protected function implementValueReadLong(): void
-    {
+    protected function implementValueReadLong(): void {
         $fn___d3d9446802a44259755d38e6d163e820 = $this->context->lookupFunction('__value__readLong');
-        $block___d3d9446802a44259755d38e6d163e820 = $fn___d3d9446802a44259755d38e6d163e820->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___d3d9446802a44259755d38e6d163e820);
-        $value = $fn___d3d9446802a44259755d38e6d163e820->getParam(0);
-
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
-        $type = $this->context->builder->load(
+    $block___d3d9446802a44259755d38e6d163e820 = $fn___d3d9446802a44259755d38e6d163e820->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___d3d9446802a44259755d38e6d163e820);
+    $value = $fn___d3d9446802a44259755d38e6d163e820->getParam(0);
+    
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
+                    $type = $this->context->builder->load(
                         $this->context->builder->structGep($value, $offset)
                     );
-        $__switches[] = $__switch = new \StdClass();
-        $__switch->type = $type->typeOf();
-        $__prev = $this->context->builder->getInsertBlock();
-        $__switch->default = $__prev->insertBasicBlock('default');
-        $__prev->moveBefore($__switch->default);
-        $__switch->end = $__switch->default->insertBasicBlock('end');
-        $__switch->endIsUsed = false;
-        $__switch->numCases = 0;
-        ++$__switch->numCases;
-        ++$__switch->numCases;
-        ++$__switch->numCases;
-
-        $__switch->switch = $this->context->builder->branchSwitch($type, $__switch->default, $__switch->numCases);
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_NATIVE_LONG)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_LONG, false), $__case);
-        } elseif (Variable::TYPE_NATIVE_LONG instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_NATIVE_LONG, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $ptr = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('int64*');
-
-        $__kind = $__type->getKind();
-        $__value = $ptr;
-        switch ($__kind) {
+    $__switches[] = $__switch = new \StdClass;
+                $__switch->type = $type->typeOf();
+                $__prev = $this->context->builder->getInsertBlock();
+                $__switch->default = $__prev->insertBasicBlock('default');
+                $__prev->moveBefore($__switch->default);
+                $__switch->end = $__switch->default->insertBasicBlock('end');
+                $__switch->endIsUsed = false;
+                $__switch->numCases = 0;
+                $__switch->numCases++;
+                $__switch->numCases++;
+                $__switch->numCases++;
+                
+                $__switch->switch = $this->context->builder->branchSwitch($type, $__switch->default, $__switch->numCases);
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_NATIVE_LONG)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_LONG, false), $__case);
+                    } elseif (Variable::TYPE_NATIVE_LONG instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_NATIVE_LONG, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $ptr = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('int64*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $ptr;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $resultPtr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -1834,58 +1040,50 @@ class Value extends Type
                                     } else {
                                         $resultPtr = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $resultPtr = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $resultPtr = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $resultPtr = $__type->constReal($ptr);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $resultPtr = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $resultPtr = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $resultPtr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $resultPtr = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -1893,25 +1091,23 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $resultPtr = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $__type = $this->context->getTypeFromString('int32');
-
-        $__kind = $__type->getKind();
-        $__value = 0;
-        switch ($__kind) {
+    $__type = $this->context->getTypeFromString('int32');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = 0;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $offset = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -1922,58 +1118,50 @@ class Value extends Type
                                     } else {
                                         $offset = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $offset = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $offset = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $offset = $__type->constReal(0);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $offset = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $offset = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $offset = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $offset = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -1981,48 +1169,46 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $offset = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $result = $this->context->builder->load($this->context->builder->gep(
+    $result = $this->context->builder->load($this->context->builder->gep(
                         $resultPtr,
                         //$this->context->context->int32Type()->constInt(0, false),
                         //$this->context->context->int32Type()->constInt(0, false),
                         $offset
                     ));
-        $this->context->builder->returnValue($result);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_NATIVE_DOUBLE)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_DOUBLE, false), $__case);
-        } elseif (Variable::TYPE_NATIVE_DOUBLE instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_NATIVE_DOUBLE, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $ptr = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('double*');
-
-        $__kind = $__type->getKind();
-        $__value = $ptr;
-        switch ($__kind) {
+    $this->context->builder->returnValue($result);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_NATIVE_DOUBLE)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_DOUBLE, false), $__case);
+                    } elseif (Variable::TYPE_NATIVE_DOUBLE instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_NATIVE_DOUBLE, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $ptr = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('double*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $ptr;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $resultPtr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -2033,58 +1219,50 @@ class Value extends Type
                                     } else {
                                         $resultPtr = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $resultPtr = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $resultPtr = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $resultPtr = $__type->constReal($ptr);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $resultPtr = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $resultPtr = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $resultPtr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $resultPtr = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -2092,25 +1270,23 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $resultPtr = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $__type = $this->context->getTypeFromString('int32');
-
-        $__kind = $__type->getKind();
-        $__value = 0;
-        switch ($__kind) {
+    $__type = $this->context->getTypeFromString('int32');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = 0;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $offset = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -2121,58 +1297,50 @@ class Value extends Type
                                     } else {
                                         $offset = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $offset = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $offset = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $offset = $__type->constReal(0);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $offset = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $offset = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $offset = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $offset = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -2180,31 +1348,29 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $offset = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $result = $this->context->builder->load($this->context->builder->gep(
+    $result = $this->context->builder->load($this->context->builder->gep(
                         $resultPtr,
                         //$this->context->context->int32Type()->constInt(0, false),
                         //$this->context->context->int32Type()->constInt(0, false),
                         $offset
                     ));
-        $__type = $this->context->getTypeFromString('int64');
-
-        $__kind = $__type->getKind();
-        $__value = $result;
-        switch ($__kind) {
+    $__type = $this->context->getTypeFromString('int64');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $result;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $return = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -2215,58 +1381,50 @@ class Value extends Type
                                     } else {
                                         $return = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $return = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $return = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $return = $__type->constReal($result);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $return = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $return = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $return = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $return = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -2274,42 +1432,40 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $return = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->returnValue($return);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_VALUE)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_VALUE, false), $__case);
-        } elseif (Variable::TYPE_VALUE instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_VALUE, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $var = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('__value__value*');
-
-        $__kind = $__type->getKind();
-        $__value = $var;
-        switch ($__kind) {
+    $this->context->builder->returnValue($return);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_VALUE)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_VALUE, false), $__case);
+                    } elseif (Variable::TYPE_VALUE instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_VALUE, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $var = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('__value__value*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $var;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $ptr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -2320,58 +1476,50 @@ class Value extends Type
                                     } else {
                                         $ptr = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $ptr = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $ptr = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $ptr = $__type->constReal($var);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $ptr = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $ptr = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $ptr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $ptr = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -2379,51 +1527,49 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $ptr = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $offset = $this->context->structFieldMap[$ptr->typeOf()->getElementType()->getName()]['value'];
-        $varPtr = $this->context->builder->structGep($ptr, $offset);
-        $result = $this->context->builder->call(
-                        $this->context->lookupFunction('__value__readLong'),
+    $offset = $this->context->structFieldMap[$ptr->typeOf()->getElementType()->getName()]['value'];
+                    $varPtr = $this->context->builder->structGep($ptr, $offset);
+    $result = $this->context->builder->call(
+                        $this->context->lookupFunction('__value__readLong') , 
                         $varPtr
-
+                        
                     );
-        $this->context->builder->returnValue($result);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-
-        $this->context->builder->positionAtEnd(end($__switches)->default);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__switch = array_pop($__switches);
-        if ($__switch->endIsUsed) {
-            $this->context->builder->positionAtEnd($__switch->end);
-        } else {
-            $__switch->end->remove();
-        }
-        $__type = $this->context->getTypeFromString('int64');
-
-        $__kind = $__type->getKind();
-        $__value = 0;
-        switch ($__kind) {
+    $this->context->builder->returnValue($result);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                
+                $this->context->builder->positionAtEnd(end($__switches)->default);
+                
+                if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                    $this->context->builder->branch(end($__switches)->end);
+                    end($__switches)->endIsUsed = true;
+                }
+                $__switch = array_pop($__switches);
+                if ($__switch->endIsUsed) {
+                    $this->context->builder->positionAtEnd($__switch->end);
+                } else {
+                    $__switch->end->remove();
+                }
+    $__type = $this->context->getTypeFromString('int64');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = 0;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $result = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -2434,58 +1580,50 @@ class Value extends Type
                                     } else {
                                         $result = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $result = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $result = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $result = $__type->constReal(0);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $result = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $result = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $result = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $result = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -2493,65 +1631,125 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $result = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->returnValue($result);
-
-        $this->context->builder->clearInsertionPosition();
+    $this->context->builder->returnValue($result);
+    
+    $this->context->builder->clearInsertionPosition();
     }
 
-    protected function implementValueReadDouble(): void
-    {
-        $fn___70efdf2ec9b086079795c442636b55fb = $this->context->lookupFunction('__value__readDouble');
-        $block___70efdf2ec9b086079795c442636b55fb = $fn___70efdf2ec9b086079795c442636b55fb->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___70efdf2ec9b086079795c442636b55fb);
-        $value = $fn___70efdf2ec9b086079795c442636b55fb->getParam(0);
-
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
-        $type = $this->context->builder->load(
-                        $this->context->builder->structGep($value, $offset)
-                    );
-        $__switches[] = $__switch = new \StdClass();
-        $__switch->type = $type->typeOf();
-        $__prev = $this->context->builder->getInsertBlock();
-        $__switch->default = $__prev->insertBasicBlock('default');
-        $__prev->moveBefore($__switch->default);
-        $__switch->end = $__switch->default->insertBasicBlock('end');
-        $__switch->endIsUsed = false;
-        $__switch->numCases = 0;
-        ++$__switch->numCases;
-        ++$__switch->numCases;
-        ++$__switch->numCases;
-
-        $__switch->switch = $this->context->builder->branchSwitch($type, $__switch->default, $__switch->numCases);
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_NATIVE_LONG)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_LONG, false), $__case);
-        } elseif (Variable::TYPE_NATIVE_LONG instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_NATIVE_LONG, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $ptr = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('int64*');
-
-        $__kind = $__type->getKind();
-        $__value = $ptr;
-        switch ($__kind) {
+    public function implementValueWriteLong(): void {
+        $fn___9bf31c7ff062936a96d3c8bd1f8f2ff3 = $this->context->lookupFunction('__value__writeLong');
+    $block___9bf31c7ff062936a96d3c8bd1f8f2ff3 = $fn___9bf31c7ff062936a96d3c8bd1f8f2ff3->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___9bf31c7ff062936a96d3c8bd1f8f2ff3);
+    $value = $fn___9bf31c7ff062936a96d3c8bd1f8f2ff3->getParam(0);
+    $long = $fn___9bf31c7ff062936a96d3c8bd1f8f2ff3->getParam(1);
+    
+    $this->context->builder->call(
+                    $this->context->lookupFunction('__value__valueDelref') , 
+                    $value
+                    
+                );
+    $__type = $this->context->getTypeFromString('int8');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = Variable::TYPE_NATIVE_LONG;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
+                                $type = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $type = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $type = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    
+                                    $type = $this->context->builder->fpToSi($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $type = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $type = $__type->constReal(Variable::TYPE_NATIVE_LONG);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    
+                                    $type = $this->context->builder->siToFp($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $type = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $type = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $type = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $type = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
+                $this->context->builder->store(
+                    $type,
+                    $this->context->builder->structGep($value, $offset)
+                );
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $ptr = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('int64*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $ptr;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
                                 $resultPtr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -2562,58 +1760,50 @@ class Value extends Type
                                     } else {
                                         $resultPtr = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $resultPtr = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $resultPtr = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $resultPtr = $__type->constReal($ptr);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $resultPtr = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $resultPtr = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $resultPtr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $resultPtr = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -2621,25 +1811,23 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $resultPtr = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $__type = $this->context->getTypeFromString('int32');
-
-        $__kind = $__type->getKind();
-        $__value = 0;
-        switch ($__kind) {
+    $__type = $this->context->getTypeFromString('int32');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = 0;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $offset = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -2650,58 +1838,50 @@ class Value extends Type
                                     } else {
                                         $offset = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $offset = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $offset = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $offset = $__type->constReal(0);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $offset = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $offset = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $offset = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $offset = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -2709,31 +1889,231 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $offset = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $result = $this->context->builder->load($this->context->builder->gep(
+    $this->context->builder->store($long, $this->context->builder->gep(
+                    $resultPtr,
+                    //$this->context->context->int32Type()->constInt(0, false),
+                    //$this->context->context->int32Type()->constInt(0, false),
+                    $offset
+                ));
+    $this->context->builder->returnVoid();
+    
+    $this->context->builder->clearInsertionPosition();
+    }
+
+    protected function implementValueReadDouble(): void {
+        $fn___70efdf2ec9b086079795c442636b55fb = $this->context->lookupFunction('__value__readDouble');
+    $block___70efdf2ec9b086079795c442636b55fb = $fn___70efdf2ec9b086079795c442636b55fb->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___70efdf2ec9b086079795c442636b55fb);
+    $value = $fn___70efdf2ec9b086079795c442636b55fb->getParam(0);
+    
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
+                    $type = $this->context->builder->load(
+                        $this->context->builder->structGep($value, $offset)
+                    );
+    $__switches[] = $__switch = new \StdClass;
+                $__switch->type = $type->typeOf();
+                $__prev = $this->context->builder->getInsertBlock();
+                $__switch->default = $__prev->insertBasicBlock('default');
+                $__prev->moveBefore($__switch->default);
+                $__switch->end = $__switch->default->insertBasicBlock('end');
+                $__switch->endIsUsed = false;
+                $__switch->numCases = 0;
+                $__switch->numCases++;
+                $__switch->numCases++;
+                $__switch->numCases++;
+                
+                $__switch->switch = $this->context->builder->branchSwitch($type, $__switch->default, $__switch->numCases);
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_NATIVE_LONG)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_LONG, false), $__case);
+                    } elseif (Variable::TYPE_NATIVE_LONG instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_NATIVE_LONG, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $ptr = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('int64*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $ptr;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
+                                $resultPtr = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $resultPtr = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $resultPtr = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    
+                                    $resultPtr = $this->context->builder->fpToSi($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $resultPtr = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $resultPtr = $__type->constReal($ptr);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    
+                                    $resultPtr = $this->context->builder->siToFp($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $resultPtr = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $resultPtr = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $resultPtr = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $resultPtr = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    $__type = $this->context->getTypeFromString('int32');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = 0;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
+                                $offset = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $offset = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $offset = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    
+                                    $offset = $this->context->builder->fpToSi($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $offset = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $offset = $__type->constReal(0);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    
+                                    $offset = $this->context->builder->siToFp($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $offset = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $offset = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $offset = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $offset = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    $result = $this->context->builder->load($this->context->builder->gep(
                         $resultPtr,
                         //$this->context->context->int32Type()->constInt(0, false),
                         //$this->context->context->int32Type()->constInt(0, false),
                         $offset
                     ));
-        $__type = $this->context->context->doubleType();
-
-        $__kind = $__type->getKind();
-        $__value = $result;
-        switch ($__kind) {
+    $__type = $this->context->context->doubleType();
+                        
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $result;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $return = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -2744,58 +2124,50 @@ class Value extends Type
                                     } else {
                                         $return = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $return = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $return = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $return = $__type->constReal($result);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $return = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $return = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $return = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $return = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -2803,42 +2175,40 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $return = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->returnValue($return);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_NATIVE_DOUBLE)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_DOUBLE, false), $__case);
-        } elseif (Variable::TYPE_NATIVE_DOUBLE instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_NATIVE_DOUBLE, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $ptr = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('double*');
-
-        $__kind = $__type->getKind();
-        $__value = $ptr;
-        switch ($__kind) {
+    $this->context->builder->returnValue($return);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_NATIVE_DOUBLE)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_NATIVE_DOUBLE, false), $__case);
+                    } elseif (Variable::TYPE_NATIVE_DOUBLE instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_NATIVE_DOUBLE, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $ptr = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('double*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $ptr;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $resultPtr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -2849,58 +2219,50 @@ class Value extends Type
                                     } else {
                                         $resultPtr = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $resultPtr = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $resultPtr = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $resultPtr = $__type->constReal($ptr);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $resultPtr = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $resultPtr = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $resultPtr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $resultPtr = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -2908,25 +2270,23 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $resultPtr = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $__type = $this->context->getTypeFromString('int32');
-
-        $__kind = $__type->getKind();
-        $__value = 0;
-        switch ($__kind) {
+    $__type = $this->context->getTypeFromString('int32');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = 0;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $offset = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -2937,58 +2297,50 @@ class Value extends Type
                                     } else {
                                         $offset = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $offset = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $offset = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $offset = $__type->constReal(0);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $offset = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $offset = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $offset = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $offset = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -2996,48 +2348,46 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $offset = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $result = $this->context->builder->load($this->context->builder->gep(
+    $result = $this->context->builder->load($this->context->builder->gep(
                         $resultPtr,
                         //$this->context->context->int32Type()->constInt(0, false),
                         //$this->context->context->int32Type()->constInt(0, false),
                         $offset
                     ));
-        $this->context->builder->returnValue($result);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_VALUE)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_VALUE, false), $__case);
-        } elseif (Variable::TYPE_VALUE instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_VALUE, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $var = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('__value__value*');
-
-        $__kind = $__type->getKind();
-        $__value = $var;
-        switch ($__kind) {
+    $this->context->builder->returnValue($result);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_VALUE)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_VALUE, false), $__case);
+                    } elseif (Variable::TYPE_VALUE instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_VALUE, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $var = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('__value__value*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $var;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $ptr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -3048,58 +2398,50 @@ class Value extends Type
                                     } else {
                                         $ptr = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $ptr = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $ptr = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $ptr = $__type->constReal($var);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $ptr = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $ptr = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $ptr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $ptr = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -3107,51 +2449,50 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $ptr = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $offset = $this->context->structFieldMap[$ptr->typeOf()->getElementType()->getName()]['value'];
-        $varPtr = $this->context->builder->structGep($ptr, $offset);
-        $result = $this->context->builder->call(
-                        $this->context->lookupFunction('__value__readDouble'),
+    $offset = $this->context->structFieldMap[$ptr->typeOf()->getElementType()->getName()]['value'];
+                    $varPtr = $this->context->builder->structGep($ptr, $offset);
+    $result = $this->context->builder->call(
+                        $this->context->lookupFunction('__value__readDouble') , 
                         $varPtr
-
+                        
                     );
-        $this->context->builder->returnValue($result);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-
-        $this->context->builder->positionAtEnd(end($__switches)->default);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__switch = array_pop($__switches);
-        if ($__switch->endIsUsed) {
-            $this->context->builder->positionAtEnd($__switch->end);
-        } else {
-            $__switch->end->remove();
-        }
-        $__type = $this->context->context->doubleType();
-
-        $__kind = $__type->getKind();
-        $__value = 0.0;
-        switch ($__kind) {
+    $this->context->builder->returnValue($result);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                
+                $this->context->builder->positionAtEnd(end($__switches)->default);
+                
+                if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                    $this->context->builder->branch(end($__switches)->end);
+                    end($__switches)->endIsUsed = true;
+                }
+                $__switch = array_pop($__switches);
+                if ($__switch->endIsUsed) {
+                    $this->context->builder->positionAtEnd($__switch->end);
+                } else {
+                    $__switch->end->remove();
+                }
+    $__type = $this->context->context->doubleType();
+                        
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = 0.0;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $result = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -3162,58 +2503,50 @@ class Value extends Type
                                     } else {
                                         $result = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $result = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $result = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $result = $__type->constReal(0.0);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $result = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $result = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $result = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $result = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -3221,64 +2554,125 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $result = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->returnValue($result);
-
-        $this->context->builder->clearInsertionPosition();
+    $this->context->builder->returnValue($result);
+    
+    $this->context->builder->clearInsertionPosition();
     }
 
-    protected function implementValueReadString(): void
-    {
-        $fn___1ff1de774005f8da13f42943881c655f = $this->context->lookupFunction('__value__readString');
-        $block___1ff1de774005f8da13f42943881c655f = $fn___1ff1de774005f8da13f42943881c655f->appendBasicBlock('main');
-        $this->context->builder->positionAtEnd($block___1ff1de774005f8da13f42943881c655f);
-        $value = $fn___1ff1de774005f8da13f42943881c655f->getParam(0);
-
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
-        $type = $this->context->builder->load(
-                        $this->context->builder->structGep($value, $offset)
-                    );
-        $__switches[] = $__switch = new \StdClass();
-        $__switch->type = $type->typeOf();
-        $__prev = $this->context->builder->getInsertBlock();
-        $__switch->default = $__prev->insertBasicBlock('default');
-        $__prev->moveBefore($__switch->default);
-        $__switch->end = $__switch->default->insertBasicBlock('end');
-        $__switch->endIsUsed = false;
-        $__switch->numCases = 0;
-        ++$__switch->numCases;
-        ++$__switch->numCases;
-
-        $__switch->switch = $this->context->builder->branchSwitch($type, $__switch->default, $__switch->numCases);
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_STRING)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_STRING, false), $__case);
-        } elseif (Variable::TYPE_STRING instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_STRING, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $ptr = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('__string__*');
-
-        $__kind = $__type->getKind();
-        $__value = $ptr;
-        switch ($__kind) {
+    public function implementValueWriteDouble(): void {
+        $fn___b6d767d2f8ed5d21a44b0e5886680cb9 = $this->context->lookupFunction('__value__writeDouble');
+    $block___b6d767d2f8ed5d21a44b0e5886680cb9 = $fn___b6d767d2f8ed5d21a44b0e5886680cb9->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___b6d767d2f8ed5d21a44b0e5886680cb9);
+    $value = $fn___b6d767d2f8ed5d21a44b0e5886680cb9->getParam(0);
+    $double = $fn___b6d767d2f8ed5d21a44b0e5886680cb9->getParam(1);
+    
+    $this->context->builder->call(
+                    $this->context->lookupFunction('__value__valueDelref') , 
+                    $value
+                    
+                );
+    $__type = $this->context->getTypeFromString('int8');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = Variable::TYPE_NATIVE_DOUBLE;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
+                                $type = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $type = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $type = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    
+                                    $type = $this->context->builder->fpToSi($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $type = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $type = $__type->constReal(Variable::TYPE_NATIVE_DOUBLE);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    
+                                    $type = $this->context->builder->siToFp($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $type = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $type = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $type = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $type = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
+                $this->context->builder->store(
+                    $type,
+                    $this->context->builder->structGep($value, $offset)
+                );
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $ptr = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('double*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $ptr;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
                                 $resultPtr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -3289,58 +2683,50 @@ class Value extends Type
                                     } else {
                                         $resultPtr = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $resultPtr = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $resultPtr = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $resultPtr = $__type->constReal($ptr);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $resultPtr = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $resultPtr = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $resultPtr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $resultPtr = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -3348,42 +2734,240 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $resultPtr = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->returnValue($resultPtr);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__case = end($__switches)->default->insertBasicBlock('case_'. 0);
-        $this->context->builder->positionAtEnd($__case);
-        if (is_int(Variable::TYPE_VALUE)) {
-            end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_VALUE, false), $__case);
-        } elseif (Variable::TYPE_VALUE instanceof \PHPLLVM\Value) {
-            end($__switches)->switch->addCase(Variable::TYPE_VALUE, $__case);
-        } else {
-            throw new \LogicException('Unknown type for switch case');
-        }
-        $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
-        $var = $this->context->builder->structGep($value, $offset);
-        $__type = $this->context->getTypeFromString('__value__value*');
-
-        $__kind = $__type->getKind();
-        $__value = $var;
-        switch ($__kind) {
+    $__type = $this->context->getTypeFromString('int32');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = 0;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
-                                $ptr = $__type->constInt($__value, false);
+                            if (!is_object($__value)) {
+                                $offset = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $offset = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $offset = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    
+                                    $offset = $this->context->builder->fpToSi($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $offset = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $offset = $__type->constReal(0);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    
+                                    $offset = $this->context->builder->siToFp($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $offset = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $offset = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $offset = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $offset = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    $this->context->builder->store($double, $this->context->builder->gep(
+                    $resultPtr,
+                    //$this->context->context->int32Type()->constInt(0, false),
+                    //$this->context->context->int32Type()->constInt(0, false),
+                    $offset
+                ));
+    $this->context->builder->returnVoid();
+    
+    $this->context->builder->clearInsertionPosition();
+    }
 
+    protected function implementValueReadString(): void {
+        $fn___1ff1de774005f8da13f42943881c655f = $this->context->lookupFunction('__value__readString');
+    $block___1ff1de774005f8da13f42943881c655f = $fn___1ff1de774005f8da13f42943881c655f->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___1ff1de774005f8da13f42943881c655f);
+    $value = $fn___1ff1de774005f8da13f42943881c655f->getParam(0);
+    
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
+                    $type = $this->context->builder->load(
+                        $this->context->builder->structGep($value, $offset)
+                    );
+    $__switches[] = $__switch = new \StdClass;
+                $__switch->type = $type->typeOf();
+                $__prev = $this->context->builder->getInsertBlock();
+                $__switch->default = $__prev->insertBasicBlock('default');
+                $__prev->moveBefore($__switch->default);
+                $__switch->end = $__switch->default->insertBasicBlock('end');
+                $__switch->endIsUsed = false;
+                $__switch->numCases = 0;
+                $__switch->numCases++;
+                $__switch->numCases++;
+                
+                $__switch->switch = $this->context->builder->branchSwitch($type, $__switch->default, $__switch->numCases);
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_STRING)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_STRING, false), $__case);
+                    } elseif (Variable::TYPE_STRING instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_STRING, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $ptr = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('__string__*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $ptr;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
+                                $resultPtr = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $resultPtr = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $resultPtr = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    
+                                    $resultPtr = $this->context->builder->fpToSi($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $resultPtr = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $resultPtr = $__type->constReal($ptr);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    
+                                    $resultPtr = $this->context->builder->siToFp($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $resultPtr = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $resultPtr = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $resultPtr = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $resultPtr = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    $this->context->builder->returnValue($resultPtr);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                $__case = end($__switches)->default->insertBasicBlock('case_' . 0);
+                    $this->context->builder->positionAtEnd($__case);
+                    if (is_int(Variable::TYPE_VALUE)) {
+                        end($__switches)->switch->addCase(end($__switches)->type->constInt(Variable::TYPE_VALUE, false), $__case);
+                    } elseif (Variable::TYPE_VALUE instanceof \PHPLLVM\Value) {
+                        end($__switches)->switch->addCase(Variable::TYPE_VALUE, $__case);
+                    } else {
+                        throw new \LogicException("Unknown type for switch case");
+                    }
+                    {  $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                    $var = $this->context->builder->structGep($value, $offset);
+    $__type = $this->context->getTypeFromString('__value__value*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = $var;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
+                                $ptr = $__type->constInt($__value, false);
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -3394,58 +2978,50 @@ class Value extends Type
                                     } else {
                                         $ptr = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $ptr = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $ptr = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $ptr = $__type->constReal($var);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $ptr = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $ptr = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $ptr = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $ptr = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -3453,53 +3029,51 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $ptr = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $offset = $this->context->structFieldMap[$var->typeOf()->getElementType()->getName()]['value'];
-        $varPtr = $this->context->builder->load(
+    $offset = $this->context->structFieldMap[$var->typeOf()->getElementType()->getName()]['value'];
+                    $varPtr = $this->context->builder->load(
                         $this->context->builder->structGep($var, $offset)
                     );
-        $result = $this->context->builder->call(
-                        $this->context->lookupFunction('__value__readString'),
+    $result = $this->context->builder->call(
+                        $this->context->lookupFunction('__value__readString') , 
                         $varPtr
-
+                        
                     );
-        $this->context->builder->returnValue($result);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-
-        $this->context->builder->positionAtEnd(end($__switches)->default);
-
-        if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
-            $this->context->builder->branch(end($__switches)->end);
-            end($__switches)->endIsUsed = true;
-        }
-        $__switch = array_pop($__switches);
-        if ($__switch->endIsUsed) {
-            $this->context->builder->positionAtEnd($__switch->end);
-        } else {
-            $__switch->end->remove();
-        }
-        $__type = $this->context->getTypeFromString('__string__*');
-
-        $__kind = $__type->getKind();
-        $__value = null;
-        switch ($__kind) {
+    $this->context->builder->returnValue($result);
+     }
+                    if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                        $this->context->builder->branch(end($__switches)->end);
+                        end($__switches)->endIsUsed = true;
+                    }
+                
+                $this->context->builder->positionAtEnd(end($__switches)->default);
+                
+                if ($this->context->builder->getInsertBlock()->getTerminator() === null) {
+                    $this->context->builder->branch(end($__switches)->end);
+                    end($__switches)->endIsUsed = true;
+                }
+                $__switch = array_pop($__switches);
+                if ($__switch->endIsUsed) {
+                    $this->context->builder->positionAtEnd($__switch->end);
+                } else {
+                    $__switch->end->remove();
+                }
+    $__type = $this->context->getTypeFromString('__string__*');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = null;
+                    switch ($__kind) {
                         case \PHPLLVM\Type::KIND_INTEGER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $result = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
@@ -3510,58 +3084,50 @@ class Value extends Type
                                     } else {
                                         $result = $this->context->builder->zExtOrBitCast($__value, $__type);
                                     }
-
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
-
+                                    
                                     $result = $this->context->builder->fpToSi($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $result = $this->context->builder->ptrToInt($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (int, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_DOUBLE:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 $result = $__type->constReal(null);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
-
+                                    
                                     $result = $this->context->builder->siToFp($__value, $__type);
-
+                                    
                                     break;
                                 case \PHPLLVM\Type::KIND_DOUBLE:
                                     $result = $this->context->builder->fpCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         case \PHPLLVM\Type::KIND_ARRAY:
                         case \PHPLLVM\Type::KIND_POINTER:
-                            if (! is_object($__value)) {
+                            if (!is_object($__value)) {
                                 // this is very likely very wrong...
                                 $result = $__type->constInt($__value, false);
-
                                 break;
                             }
                             $__other_type = $__value->typeOf();
                             switch ($__other_type->getKind()) {
                                 case \PHPLLVM\Type::KIND_INTEGER:
                                     $result = $this->context->builder->intToPtr($__value, $__type);
-
                                     break;
                                 case \PHPLLVM\Type::KIND_ARRAY:
                                     // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
@@ -3569,18 +3135,221 @@ class Value extends Type
                                     // break;
                                 case \PHPLLVM\Type::KIND_POINTER:
                                     $result = $this->context->builder->pointerCast($__value, $__type);
-
                                     break;
                                 default:
-                                    throw new \LogicException('Unknown how to handle type pair (double, '.$__other_type->toString().')');
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
                             }
-
                             break;
                         default:
-                            throw new \LogicException('Unsupported type cast: '.$__type->toString());
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
                     }
-        $this->context->builder->returnValue($result);
-
-        $this->context->builder->clearInsertionPosition();
+    $this->context->builder->returnValue($result);
+    
+    $this->context->builder->clearInsertionPosition();
     }
+
+    public function implementValueWriteString(): void {
+        $fn___33e75ff09dd601bbe69f351039152189 = $this->context->lookupFunction('__value__writeString');
+    $block___33e75ff09dd601bbe69f351039152189 = $fn___33e75ff09dd601bbe69f351039152189->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___33e75ff09dd601bbe69f351039152189);
+    $value = $fn___33e75ff09dd601bbe69f351039152189->getParam(0);
+    $string = $fn___33e75ff09dd601bbe69f351039152189->getParam(1);
+    
+    $this->context->builder->call(
+                    $this->context->lookupFunction('__value__valueDelref') , 
+                    $value
+                    
+                );
+    $__type = $this->context->getTypeFromString('int8');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = Variable::TYPE_STRING;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
+                                $type = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $type = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $type = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    
+                                    $type = $this->context->builder->fpToSi($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $type = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $type = $__type->constReal(Variable::TYPE_STRING);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    
+                                    $type = $this->context->builder->siToFp($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $type = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $type = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $type = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $type = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
+                $this->context->builder->store(
+                    $type,
+                    $this->context->builder->structGep($value, $offset)
+                );
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['value'];
+                $this->context->builder->store(
+                    $string,
+                    $this->context->builder->structGep($value, $offset)
+                );
+    $this->context->builder->returnVoid();
+    
+    $this->context->builder->clearInsertionPosition();
+    }
+
+    public function implementValueWriteNull(): void {
+        $fn___34173cb38f07f89ddbebc2ac9128303f = $this->context->lookupFunction('__value__writeNull');
+    $block___34173cb38f07f89ddbebc2ac9128303f = $fn___34173cb38f07f89ddbebc2ac9128303f->appendBasicBlock('main');
+    $this->context->builder->positionAtEnd($block___34173cb38f07f89ddbebc2ac9128303f);
+    $value = $fn___34173cb38f07f89ddbebc2ac9128303f->getParam(0);
+    
+    $this->context->builder->call(
+                    $this->context->lookupFunction('__value__valueDelref') , 
+                    $value
+                    
+                );
+    $__type = $this->context->getTypeFromString('int8');
+                        
+                    
+                    $__kind = $__type->getKind();
+                    $__value = Variable::TYPE_NULL;
+                    switch ($__kind) {
+                        case \PHPLLVM\Type::KIND_INTEGER:
+                            if (!is_object($__value)) {
+                                $type = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    if ($__other_type->getWidth() >= $__type->getWidth()) {
+                                        $type = $this->context->builder->truncOrBitCast($__value, $__type);
+                                    } else {
+                                        $type = $this->context->builder->zExtOrBitCast($__value, $__type);
+                                    }
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    
+                                    $type = $this->context->builder->fpToSi($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $type = $this->context->builder->ptrToInt($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (int, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_DOUBLE:
+                            if (!is_object($__value)) {
+                                $type = $__type->constReal(Variable::TYPE_NULL);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    
+                                    $type = $this->context->builder->siToFp($__value, $__type);
+                                    
+                                    break;
+                                case \PHPLLVM\Type::KIND_DOUBLE:
+                                    $type = $this->context->builder->fpCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        case \PHPLLVM\Type::KIND_ARRAY:
+                        case \PHPLLVM\Type::KIND_POINTER:
+                            if (!is_object($__value)) {
+                                // this is very likely very wrong...
+                                $type = $__type->constInt($__value, false);
+                                break;
+                            }
+                            $__other_type = $__value->typeOf();
+                            switch ($__other_type->getKind()) {
+                                case \PHPLLVM\Type::KIND_INTEGER:
+                                    $type = $this->context->builder->intToPtr($__value, $__type);
+                                    break;
+                                case \PHPLLVM\Type::KIND_ARRAY:
+                                    // $__tmp = $this->context->builder->($__value, $this->context->context->int64Type());
+                                    // $(result) = $this->context->builder->intToPtr($__tmp, $__type);
+                                    // break;
+                                case \PHPLLVM\Type::KIND_POINTER:
+                                    $type = $this->context->builder->pointerCast($__value, $__type);
+                                    break;
+                                default:
+                                    throw new \LogicException("Unknown how to handle type pair (double, " . $__other_type->toString() . ")");
+                            }
+                            break;
+                        default:
+                            throw new \LogicException("Unsupported type cast: " . $__type->toString());
+                    }
+    $offset = $this->context->structFieldMap[$value->typeOf()->getElementType()->getName()]['type'];
+                $this->context->builder->store(
+                    $type,
+                    $this->context->builder->structGep($value, $offset)
+                );
+    $this->context->builder->returnVoid();
+    
+    $this->context->builder->clearInsertionPosition();
+    }
+
 }

--- a/lib/JIT/Call/Native.php
+++ b/lib/JIT/Call/Native.php
@@ -1,7 +1,7 @@
 <?php
 
-// This file is generated and changes you make will be lost.
-// Change /compiler/lib/JIT/Call/Native.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT/Call/Native.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code

--- a/lib/JIT/Context.php
+++ b/lib/JIT/Context.php
@@ -89,7 +89,7 @@ class Context {
         $this->helper = new Helper($this);
         
         $this->refcount = new Builtin\Refcount($this, $loadType);
-        $this->memory = new Builtin\MemoryManager\Native($this, $loadType);
+        $this->memory = Builtin\MemoryManager::load($this, $loadType);
         $this->output = new Builtin\Output($this, $loadType);
         $this->type = new Builtin\Type($this, $loadType);
         $this->internal = new Builtin\Internal($this, $loadType);

--- a/lib/JIT/Helper.php
+++ b/lib/JIT/Helper.php
@@ -1,7 +1,7 @@
 <?php
 
-// This file is generated and changes you make will be lost.
-// Change /compiler/lib/JIT/Helper.pre instead.
+# This file is generated, changes you make will be lost.
+# Make your changes in /compiler/lib/JIT/Helper.pre instead.
 
 /*
  * This file is part of PHP-Compiler, a PHP CFG Compiler for PHP code


### PR DESCRIPTION
This updates the PHP memory manager based on the Native
memory manager preprocessor, and simply changes the names
of the malloc family function calls.

A MemoryManager::load function is re-added to select the
memory manager to use based on the loadtype passed.