### PR TITLE
Add include OpCode

### DIFF
--- a/lib/Compiler.php
+++ b/lib/Compiler.php
@@ -496,6 +496,11 @@ class Compiler {
                     );
                 }
                 return $return;
+            case Op\Expr\Include_::class:
+                return [new OpCode(
+                     OpCode::TYPE_INCLUDE,
+		     $this->compileOperand($expr->expr, $block, true),
+		)];
         }
         throw new \LogicException("Unsupported expression: " . $expr->getType());
     }

--- a/lib/OpCode.php
+++ b/lib/OpCode.php
@@ -65,6 +65,7 @@ class OpCode {
     const TYPE_INIT_ARRAY = 53;
     const TYPE_ADD_ARRAY_ELEMENT = 54;
     const TYPE_STATICCALL_INIT = 55;
+    const TYPE_INCLUDE = 56;
 
     public int $type;
     public ?int $arg1;

--- a/lib/VM.php
+++ b/lib/VM.php
@@ -279,6 +279,11 @@ restart:
                     $dst = $frame->scope[$op->arg1];
                     $dst->bool($value);
                     break;
+                case OpCode::TYPE_INCLUDE:
+                    $file = $frame->scope[$op->arg1]->toString();
+                    $parsed = $this->context->runtime->parseAndCompileFile($file);
+		    $this->context->runtime->run($parsed);
+                    break;
                 default:
                     throw new \LogicException("VM OpCode Not Implemented: " . $op->getType());
             }

--- a/lib/VM.php
+++ b/lib/VM.php
@@ -286,7 +286,6 @@ restart:
 		    $this->context->push($frame);
 		    $frame = $new;
 		    goto restart;
-                    break;
                 default:
                     throw new \LogicException("VM OpCode Not Implemented: " . $op->getType());
             }

--- a/lib/VM.php
+++ b/lib/VM.php
@@ -282,7 +282,10 @@ restart:
                 case OpCode::TYPE_INCLUDE:
                     $file = $frame->scope[$op->arg1]->toString();
                     $parsed = $this->context->runtime->parseAndCompileFile($file);
-		    $this->context->runtime->run($parsed);
+		    $new = $parsed->getFrame($this->context);
+		    $this->context->push($frame);
+		    $frame = $new;
+		    goto restart;
                     break;
                 default:
                     throw new \LogicException("VM OpCode Not Implemented: " . $op->getType());


### PR DESCRIPTION
This adds an OpCode to emit when encontering a PHPCfg\Expr\Include_
in compile.

Support for it isn't included in the JIT, or AOT, but at least
it allows bin/print.php to handle files that have an include
statement without throwing an exception while trying to generate the
OpCodes.

Fixes #62.