### PR TITLE
Add support for multiple clang versions

### DIFF
--- a/lib/JIT/Context.php
+++ b/lib/JIT/Context.php
@@ -180,8 +180,16 @@ class Context {
             $machine->emitToFile($this->module, $this->debugFile . '.s', $machine::CODEGEN_FILE_TYPE_ASM);
         }
         $machine->emitToFile($this->module, $file . '.o', $machine::CODEGEN_FILE_TYPE_OBJECT);
-        exec('clang-4.0  ' . escapeshellarg($file . '.o') . ' -o ' . escapeshellarg($file));
-        unlink($file . '.o');
+        $clangFiles = ['clang', 'clang-9', 'clang-8', 'clang-7', 'clang-4.0'];
+        foreach ($clangFiles as $clang) {
+            $test = exec('which ' . $clang);
+            if ($test !== '') {
+                exec($clang . '  ' . escapeshellarg($file . '.o') . ' -o ' . escapeshellarg($file));
+                unlink($file . '.o');
+                return;
+            }
+        }
+        throw new \LogicException('No supported version of clang found, is it installed?');
     }
 
     public function compileInPlace() {


### PR DESCRIPTION
This PR addresses an issue where clang-4.0 was hard-coded.