### PR TITLE
Add support for windows run with cygwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ phan:
 
 .PHONY: test
 test: rebuild-changed
-	docker run -v $(shell pwd):/compiler ircmaxell/php-compiler:16.04-dev php vendor/bin/phpunit
+	docker run -v $(shell pwd):/compiler ircmaxell/php-compiler:16.04-dev vendor/bin/phpunit
 
 .PHONY: test-18
 test-18: rebuild-changed
-	docker run -v $(shell pwd):/compiler ircmaxell/php-compiler:18.04-dev php vendor/bin/phpunit
+	docker run -v $(shell pwd):/compiler ircmaxell/php-compiler:18.04-dev vendor/bin/phpunit


### PR DESCRIPTION
I removed the php command because there is a cygwin support layer in bin/phpunit. Im no windows guy but looks fine for me?

Error:
```
purhur@purhur-PC MINGW64 ~/php-compiler (master)
$ docker run -v /c/Users/purhur/php-compiler:/compiler ircmaxell/php-compiler:1
6.04-dev php vendor/bin/phpunit

dir=$(cd "${0%[/\\]*}" > /dev/null; cd '../phpunit/phpunit' && pwd)

if [ -d /proc/cygdrive ]; then
    case $(which php) in
        $(readlink -n /proc/cygdrive)/*)
            # We are in Cygwin using Windows php, so the path must be translated
            dir=$(cygpath -m "$dir");
            ;;
    esac
fi

"${dir}/phpunit" "$@"
```

With the fix:
```
purhur@purhur-PC MINGW64 ~/php-compiler (master)
$ docker run -v /c/Users/purhur/php-compiler:/compiler ircmaxell/php-compiler:1
6.04-dev vendor/bin/phpunit
PHPUnit 8.2-g21ee615 by Sebastian Bergmann and contributors.

..........................................................        58 / 58 (100%)

Time: 1.29 minutes, Memory: 6.00 MB

OK (58 tests, 86 assertions)
```

Without the php it runs fine with Ubutu 16 as host and windows 7 with cygwin docker-for-windows console as host system.